### PR TITLE
[refactor] Reorganize Gmail data tables and improve thread handling

### DIFF
--- a/app/(dashboard)/_components/content-analytics/components/ContentAnalyticsScreen.tsx
+++ b/app/(dashboard)/_components/content-analytics/components/ContentAnalyticsScreen.tsx
@@ -79,10 +79,17 @@ export function ContentAnalyticsScreen() {
     !authLoading && firebaseUser?.uid ? { userId: firebaseUser.uid } : "skip"
   );
 
-  // Console log YouTube data for debugging
+  // Fetch Gmail threads from Convex
+  const gmailThreads = useQuery(
+    api.gmailQueries.listUserGmailThreads,
+    !authLoading && firebaseUser?.uid ? { userId: firebaseUser.uid } : "skip"
+  );
+
+  // Console log data for debugging
   useEffect(() => {
     console.log('YouTube Videos from Convex:', youtubeVideos);
-  }, [youtubeVideos]);
+    console.log('Gmail Threads from Convex:', gmailThreads);
+  }, [youtubeVideos, gmailThreads]);
   
   const allContentItems: AnyContentItem[] | undefined | null = useMemo(() => {
     // Combine actual fetched data from all sources
@@ -123,23 +130,42 @@ export function ContentAnalyticsScreen() {
       }
     }
     
+    // Add real Gmail data if available
+    if (gmailThreads && Array.isArray(gmailThreads) && gmailThreads.length > 0) {
+      console.log('Adding real Gmail threads to combinedContent:', gmailThreads.length);
+      combinedItems.push(...gmailThreads);
+    } else {
+      // Only add mock Gmail data if we don't have real data AND we're not still loading
+      if (gmailThreads !== undefined) {
+        console.log('Adding mock Gmail data as fallback');
+        combinedItems.push(...getMockGmailItems(2));
+      }
+    }
+    
     // Always add mock Instagram data for now
     combinedItems.push(getMockInstagramItem('mock-insta'));
     
-    // Always add mock Gmail data for now
-    combinedItems.push(...getMockGmailItems(2));
-    
     console.log('Final combined content items:', combinedItems.length);
     return combinedItems;
-  }, [youtubeVideos]);
+  }, [youtubeVideos, gmailThreads]);
 
   // Navigate to chat with content context
   const discussContent = (item: AnyContentItem) => {
+    // Create a context object with the basic content info
     const context = {
       platform: item.platform,
       contentId: item.id,
-      // Add other relevant context, e.g., title, key metrics
+      // Include analysis if it exists
+      analysis: (item as any).aiAnalysis || null,
+      // Include title if available
+      title: item.platform === 'youtube' 
+        ? (item as YouTubeContentItem).content?.title
+        : item.platform === 'instagram'
+          ? (item as InstagramContentItem).content?.text
+          : (item as GmailContentItem).content?.subject
     };
+    
+    console.log('Sending to chat with context:', context);
     const encodedContext = encodeURIComponent(JSON.stringify(context));
     router.push(`/chat?contentContext=${encodedContext}`);
   };
@@ -154,40 +180,47 @@ export function ContentAnalyticsScreen() {
 
   // Render loading state if needed
   if (authLoading) {
-    return <LoadingState type="auth" />;
+    return <LoadingState type="auth" />
   }
 
   if (!firebaseUser) {
     return <LoadingState type="error" />;
   }
 
-  if (youtubeVideos === undefined) {
+  if (youtubeVideos === undefined || gmailThreads === undefined) {
     return <LoadingState type="content" />;
   }
 
-  // Create a special set of items that directly includes YouTube videos
+  // Create arrays of platform-specific items
   const youtubeItemsArray = youtubeVideos && Array.isArray(youtubeVideos) ? youtubeVideos : [];
+  const gmailItemsArray = gmailThreads && Array.isArray(gmailThreads) ? gmailThreads : [];
   
-  // Log YouTube items before filtering
+  // Log platform items for debugging
   console.log('Direct YouTube items available:', youtubeItemsArray.length, youtubeItemsArray);
+  console.log('Direct Gmail items available:', gmailItemsArray.length, gmailItemsArray);
   
-  // Apply normal filtering for non-YouTube content
-  const filteredContent = selectedPlatform === 'youtube' 
-    ? [...youtubeItemsArray] // If YouTube tab selected, directly use YouTube items 
-    : sortAndFilterContent(
-        combinedContent,
-        selectedPlatform,
-        selectedEmailType,
-        sortBy,
-        timeRange
-      );
+  // Apply filtering based on selected platform
+  let filteredContent: AnyContentItem[] = [];
   
-  // Final display items - ensure YouTube items are always included when YouTube tab is selected
-  const displayItems = selectedPlatform === 'youtube' 
-    ? filteredContent 
-    : selectedPlatform === 'all' 
-      ? [...filteredContent, ...youtubeItemsArray] // Include YouTube items when 'all' is selected
-      : filteredContent;
+  if (selectedPlatform === 'youtube') {
+    // If YouTube tab selected, directly use YouTube items
+    filteredContent = [...youtubeItemsArray];
+  } else if (selectedPlatform === 'gmail') {
+    // If Gmail tab selected, directly use Gmail items
+    filteredContent = [...gmailItemsArray];
+  } else {
+    // Otherwise, use combined content with sorting and filtering
+    filteredContent = sortAndFilterContent(
+      combinedContent,
+      selectedPlatform,
+      selectedEmailType,
+      sortBy,
+      timeRange
+    );
+  }
+  
+  // Final display items
+  const displayItems = filteredContent;
   
   // Log the final items to be displayed
   console.log('Final displayItems:', displayItems.length, 

--- a/app/(dashboard)/_components/content-analytics/modals/YoutubeModal.tsx
+++ b/app/(dashboard)/_components/content-analytics/modals/YoutubeModal.tsx
@@ -328,7 +328,21 @@ export const YoutubeModal: React.FC<YoutubeModalProps> = ({
 
         {/* Footer */}
         <div className="px-6 py-4 border-t dark:border-gray-800 flex items-center justify-end gap-3 flex-shrink-0">
-          <Button onClick={() => onDiscussContent(selectedContent)} className="bg-heycontent-light-yellow hover:bg-heycontent-yellow/90 text-black">
+          <Button 
+            onClick={() => {
+              // Include analysis in the content item if it exists
+              if (aiAnalysis) {
+                const contentWithAnalysis = {
+                  ...selectedContent,
+                  aiAnalysis: aiAnalysis
+                };
+                onDiscussContent(contentWithAnalysis);
+              } else {
+                onDiscussContent(selectedContent);
+              }
+            }} 
+            className="bg-heycontent-light-yellow hover:bg-heycontent-yellow/90 text-black"
+          >
             <MessageSquare className="w-4 h-4 mr-2" />
             Discuss with Content
           </Button>

--- a/convex/gmailMutations.ts
+++ b/convex/gmailMutations.ts
@@ -230,9 +230,11 @@ export const disconnectGmail = mutation({
         }
         
         // Delete the items
-        for (const item of items) {
-          await ctx.db.delete(item._id);
-          totalDeleted++;
+        const batchSize = 100;
+        for (let i = 0; i < items.length; i += batchSize) {
+          const batch = items.slice(i, i + batchSize);
+          await Promise.all(batch.map(item => ctx.db.delete(item._id)));
+          totalDeleted += batch.length;
         }
       }
       

--- a/convex/gmailMutations.ts
+++ b/convex/gmailMutations.ts
@@ -60,6 +60,8 @@ export const storeGmailMessage = mutation({
     email: v.string(),
     messageId: v.string(),
     threadId: v.string(),
+    from: v.optional(v.string()),
+    subject: v.optional(v.string()),
     snippet: v.string(),
     historyId: v.optional(v.string()),
     internalDate: v.optional(v.number()),
@@ -69,46 +71,49 @@ export const storeGmailMessage = mutation({
   },
   handler: async (ctx, args) => {
     try {
-      const timestamp = Date.now();
+      const now = Date.now();
       
       // Check if the message already exists
       const existingMessage = await ctx.db
-        .query("gmailData")
-        .withIndex("by_resource_id", (q) => q.eq("resourceId", args.messageId))
+        .query("gmailMessages")
+        .withIndex("by_messageId", (q) => q.eq("messageId", args.messageId))
         .filter((q) => 
           q.eq(q.field("userId"), args.userId) && 
-          q.eq(q.field("email"), args.email) &&
-          q.eq(q.field("resourceType"), "message")
+          q.eq(q.field("email"), args.email)
         )
         .first();
 
       if (existingMessage) {
         // Update existing message
         await ctx.db.patch(existingMessage._id, {
+          from: args.from,
+          subject: args.subject,
           snippet: args.snippet,
           historyId: args.historyId,
-          internalDate: args.internalDate,
+          internalDate: args.internalDate ? args.internalDate.toString() : undefined,
           labelIds: args.labelIds,
           data: args.payload,
           sizeEstimate: args.sizeEstimate,
-          timestamp,
+          updatedAt: now,
         });
         return { status: "updated", messageId: existingMessage._id };
       } else {
         // Insert new message
-        const messageId = await ctx.db.insert("gmailData", {
+        const messageId = await ctx.db.insert("gmailMessages", {
           userId: args.userId,
           email: args.email,
-          resourceType: "message",
-          resourceId: args.messageId,
+          messageId: args.messageId,
           threadId: args.threadId,
+          from: args.from,
+          subject: args.subject,
           snippet: args.snippet,
           historyId: args.historyId,
-          internalDate: args.internalDate,
+          internalDate: args.internalDate ? args.internalDate.toString() : undefined,
           labelIds: args.labelIds,
           data: args.payload,
           sizeEstimate: args.sizeEstimate,
-          timestamp,
+          createdAt: now,
+          updatedAt: now,
         });
         return { status: "created", messageId };
       }
@@ -125,55 +130,62 @@ export const storeGmailThread = mutation({
     userId: v.string(),
     email: v.string(),
     threadId: v.string(),
-    snippet: v.string(),
+    snippet: v.optional(v.string()),
     historyId: v.optional(v.string()),
-    messages: v.array(v.string()),
+    labelIds: v.optional(v.array(v.string())),
+    message_count: v.optional(v.number()),
+    messages: v.optional(v.array(v.object({
+      id: v.string(),
+      from: v.optional(v.string()),
+      subject: v.optional(v.string()),
+      snippet: v.optional(v.string()),
+      label_ids: v.optional(v.array(v.string())),
+    }))),
     threadData: v.optional(v.any()),
   },
   handler: async (ctx, args) => {
     try {
-      const timestamp = Date.now();
+      const now = Date.now();
       
       // Check if the thread already exists
       const existingThread = await ctx.db
-        .query("gmailData")
-        .withIndex("by_resource_id", (q) => q.eq("resourceId", args.threadId))
+        .query("gmailThreads")
+        .withIndex("by_threadId", (q) => q.eq("threadId", args.threadId))
         .filter((q) => 
           q.eq(q.field("userId"), args.userId) && 
-          q.eq(q.field("email"), args.email) &&
-          q.eq(q.field("resourceType"), "thread")
+          q.eq(q.field("email"), args.email)
         )
         .first();
 
-      // Prepare the thread data object
-      const data = args.threadData || {
-        messages: args.messages,
-        snippet: args.snippet,
-        historyId: args.historyId,
-      };
+      // Prepare data object
+      const data = args.threadData || {};
 
       if (existingThread) {
         // Update existing thread
         await ctx.db.patch(existingThread._id, {
           snippet: args.snippet,
           historyId: args.historyId,
+          labelIds: args.labelIds,
+          message_count: args.message_count,
           messages: args.messages,
           data,
-          timestamp,
+          updatedAt: now,
         });
         return { status: "updated", threadId: existingThread._id };
       } else {
         // Insert new thread
-        const threadId = await ctx.db.insert("gmailData", {
+        const threadId = await ctx.db.insert("gmailThreads", {
           userId: args.userId,
           email: args.email,
-          resourceType: "thread",
-          resourceId: args.threadId,
+          threadId: args.threadId,
           snippet: args.snippet,
           historyId: args.historyId,
+          labelIds: args.labelIds,
+          message_count: args.message_count,
           messages: args.messages,
           data,
-          timestamp,
+          createdAt: now,
+          updatedAt: now,
         });
         return { status: "created", threadId };
       }
@@ -194,23 +206,38 @@ export const disconnectGmail = mutation({
     const { userId, email } = args;
 
     try {
-      // Delete Gmail data (accounts, messages, and threads)
-      let gmailData;
+      let totalDeleted = 0;
       
-      if (email) {
-        // Delete only data for the specified email
-        gmailData = await ctx.db
-          .query("gmailData")
-          .withIndex("by_email", (q) => q.eq("userId", userId).eq("email", email))
-          .collect();
-      } else {
-        // Delete all data for this user
-        gmailData = await ctx.db
-          .query("gmailData")
-          .withIndex("by_user", (q) => q.eq("userId", userId))
-          .collect();
+      // Define the collections to clean up
+      const collections = ['gmailAccounts', 'gmailThreads', 'gmailMessages', 'gmailHistory'];
+      
+      // Delete data from each collection
+      for (const collection of collections) {
+        let items;
+        if (email) {
+          // Delete only data for the specified email
+          items = await ctx.db
+            .query(collection as any)
+            .withIndex("by_email", (q) => q.eq("email", email))
+            .filter(q => q.eq(q.field("userId"), userId))
+            .collect();
+        } else {
+          // Delete all data for this user
+          items = await ctx.db
+            .query(collection as any)
+            .withIndex("by_userId", (q) => q.eq("userId", userId))
+            .collect();
+        }
         
-        // If no specific email is provided, also delete tokens
+        // Delete the items
+        for (const item of items) {
+          await ctx.db.delete(item._id);
+          totalDeleted++;
+        }
+      }
+      
+      // If no specific email is provided, also delete tokens
+      if (!email) {
         const tokens = await ctx.db
           .query("gmailTokens")
           .withIndex("by_userId", (q) => q.eq("userId", userId))
@@ -218,17 +245,13 @@ export const disconnectGmail = mutation({
 
         for (const token of tokens) {
           await ctx.db.delete(token._id);
+          totalDeleted++;
         }
-      }
-      
-      // Delete all collected data items
-      for (const data of gmailData) {
-        await ctx.db.delete(data._id);
       }
 
       return { 
         success: true, 
-        itemsDeleted: gmailData.length 
+        itemsDeleted: totalDeleted 
       };
     } catch (error) {
       console.error('Error disconnecting Gmail:', error);
@@ -245,6 +268,8 @@ export const storeBatchGmailMessages = mutation({
     messages: v.array(v.object({
       messageId: v.string(),
       threadId: v.string(),
+      from: v.optional(v.string()),
+      subject: v.optional(v.string()),
       snippet: v.string(),
       historyId: v.optional(v.string()),
       internalDate: v.optional(v.number()),
@@ -255,48 +280,51 @@ export const storeBatchGmailMessages = mutation({
   },
   handler: async (ctx, args) => {
     try {
-      const timestamp = Date.now();
+      const now = Date.now();
       const results = [];
       
       for (const message of args.messages) {
         // Check if the message already exists
         const existingMessage = await ctx.db
-          .query("gmailData")
-          .withIndex("by_resource_id", (q) => q.eq("resourceId", message.messageId))
+          .query("gmailMessages")
+          .withIndex("by_messageId", (q) => q.eq("messageId", message.messageId))
           .filter((q) => 
             q.eq(q.field("userId"), args.userId) && 
-            q.eq(q.field("email"), args.email) &&
-            q.eq(q.field("resourceType"), "message")
+            q.eq(q.field("email"), args.email)
           )
           .first();
 
         if (existingMessage) {
           // Update existing message
           await ctx.db.patch(existingMessage._id, {
+            from: message.from,
+            subject: message.subject,
             snippet: message.snippet,
             historyId: message.historyId,
-            internalDate: message.internalDate,
+            internalDate: message.internalDate ? message.internalDate.toString() : undefined,
             labelIds: message.labelIds,
             data: message.payload,
             sizeEstimate: message.sizeEstimate,
-            timestamp,
+            updatedAt: now,
           });
           results.push({ messageId: message.messageId, status: "updated" });
         } else {
           // Insert new message
-          await ctx.db.insert("gmailData", {
+          await ctx.db.insert("gmailMessages", {
             userId: args.userId,
             email: args.email,
-            resourceType: "message",
-            resourceId: message.messageId,
+            messageId: message.messageId,
             threadId: message.threadId,
+            from: message.from,
+            subject: message.subject,
             snippet: message.snippet,
             historyId: message.historyId,
-            internalDate: message.internalDate,
+            internalDate: message.internalDate ? message.internalDate.toString() : undefined,
             labelIds: message.labelIds,
             data: message.payload,
             sizeEstimate: message.sizeEstimate,
-            timestamp,
+            createdAt: now,
+            updatedAt: now,
           });
           results.push({ messageId: message.messageId, status: "created" });
         }
@@ -320,11 +348,12 @@ export const storeGmailFullProfile = mutation({
   },
   handler: async (ctx, args) => {
     try {
-      const timestamp = Date.now();
+      const now = Date.now();
       const { userId, account, messages, threads } = args;
       if (!account || !account.email) {
         throw new Error("Account and email are required");
       }
+      
       // Extract fields from account
       const email = account.email;
       const profile = {
@@ -334,175 +363,238 @@ export const storeGmailFullProfile = mutation({
         historyId: account.historyId,
         labelsTotal: account.labelsTotal,
       };
-      const profileData = account;
+
       // Check if the account already exists
       const existingAccount = await ctx.db
-        .query("gmailData")
-        .withIndex("by_resource_id", (q) => q.eq("resourceId", email))
-        .filter((q) => 
-          q.eq(q.field("userId"), userId) && 
-          q.eq(q.field("resourceType"), "account")
-        )
+        .query("gmailAccounts")
+        .withIndex("by_email", (q) => q.eq("email", email))
+        .filter(q => q.eq(q.field("userId"), userId))
         .first();
+        
       if (existingAccount) {
         // Update existing account
         await ctx.db.patch(existingAccount._id, {
-          data: profileData,
           messagesTotal: profile.messagesTotal,
           threadsTotal: profile.threadsTotal,
           historyId: profile.historyId,
           labelsTotal: profile.labelsTotal,
-          timestamp,
+          data: account,
+          updatedAt: now,
         });
-        // Store messages and threads if provided
+        
+        // Store messages if provided
         if (Array.isArray(messages)) {
           for (const msg of messages) {
-            const resourceId = msg.id || msg.messageId;
-            if (!resourceId) {
-              console.warn(`Skipping message with undefined resourceId: ${JSON.stringify(msg)}`);
+            const messageId = msg.id || msg.messageId;
+            if (!messageId) {
+              console.warn(`Skipping message with undefined messageId: ${JSON.stringify(msg)}`);
               continue;
             }
+            
+            const threadId = msg.threadId;
+            const from = msg.payload?.headers?.find((h: any) => h.name.toLowerCase() === 'from')?.value;
+            const subject = msg.payload?.headers?.find((h: any) => h.name.toLowerCase() === 'subject')?.value;
+            const snippet = msg.snippet || '';
+            
             const existingMsg = await ctx.db
-              .query("gmailData")
-              .withIndex("by_resource_id", (q) => q.eq("resourceId", resourceId))
-              .filter((q) => 
+              .query("gmailMessages")
+              .withIndex("by_messageId", (q) => q.eq("messageId", messageId))
+              .filter(q => 
                 q.eq(q.field("userId"), userId) && 
-                q.eq(q.field("email"), email) &&
-                q.eq(q.field("resourceType"), "message")
+                q.eq(q.field("email"), email)
               )
               .first();
             
             if (existingMsg) {
               // Update existing message
               await ctx.db.patch(existingMsg._id, {
+                from,
+                subject,
+                snippet,
                 data: msg,
-                timestamp,
+                updatedAt: now,
               });
             } else {
               // Insert new message
-              await ctx.db.insert("gmailData", {
+              await ctx.db.insert("gmailMessages", {
                 userId,
                 email,
-                resourceType: "message",
-                resourceId,
+                messageId,
+                threadId,
+                from,
+                subject,
+                snippet,
+                labelIds: msg.labelIds,
+                historyId: msg.historyId,
+                internalDate: msg.internalDate ? msg.internalDate.toString() : undefined,
+                sizeEstimate: msg.sizeEstimate,
                 data: msg,
-                timestamp,
+                createdAt: now,
+                updatedAt: now,
               });
             }
           }
         }
+        
+        // Store threads if provided
         if (Array.isArray(threads)) {
           for (const thread of threads) {
-            const resourceId = thread.id || thread.threadId;
+            // Check for threadId in multiple possible locations
+            const threadId = thread.id || thread.threadId || thread.data?.thread_id || thread.resourceId;
+            if (!threadId) {
+              console.warn(`Skipping thread with undefined threadId: ${JSON.stringify(thread)}`);
+              continue;
+            }
+            
+            // Extract messages from the thread if available
+            const threadMessages = thread.messages || [];
+            const message_count = threadMessages.length;
+            
+            // Map the messages to the correct format
+            const formattedMessages = threadMessages.map((m: any) => {
+              const from = m.payload?.headers?.find((h: any) => h.name.toLowerCase() === 'from')?.value;
+              const subject = m.payload?.headers?.find((h: any) => h.name.toLowerCase() === 'subject')?.value;
+              
+              return {
+                id: m.id,
+                from,
+                subject,
+                snippet: m.snippet,
+                label_ids: m.labelIds
+              };
+            });
+            
             const existingThread = await ctx.db
-              .query("gmailData")
-              .withIndex("by_resource_id", (q) => q.eq("resourceId", resourceId))
-              .filter((q) => 
+              .query("gmailThreads")
+              .withIndex("by_threadId", (q) => q.eq("threadId", threadId))
+              .filter(q => 
                 q.eq(q.field("userId"), userId) && 
-                q.eq(q.field("email"), email) &&
-                q.eq(q.field("resourceType"), "thread")
+                q.eq(q.field("email"), email)
               )
               .first();
             
             if (existingThread) {
               // Update existing thread
               await ctx.db.patch(existingThread._id, {
+                snippet: thread.snippet,
+                historyId: thread.historyId,
+                labelIds: thread.labelIds,
+                message_count,
+                messages: formattedMessages,
                 data: thread,
-                timestamp,
+                updatedAt: now,
               });
             } else {
               // Insert new thread
-              await ctx.db.insert("gmailData", {
+              await ctx.db.insert("gmailThreads", {
                 userId,
                 email,
-                resourceType: "thread",
-                resourceId,
+                threadId,
+                snippet: thread.snippet,
+                historyId: thread.historyId,
+                labelIds: thread.labelIds,
+                message_count,
+                messages: formattedMessages,
                 data: thread,
-                timestamp,
+                createdAt: now,
+                updatedAt: now,
               });
             }
           }
         }
+        
         return { status: "updated", accountId: existingAccount._id };
       } else {
         // Insert new account
-        const accountId = await ctx.db.insert("gmailData", {
+        const accountId = await ctx.db.insert("gmailAccounts", {
           userId,
           email,
-          resourceType: "account",
-          resourceId: email, // Use the email as the resource ID for accounts
-          data: profileData,
+          historyId: profile.historyId,
           messagesTotal: profile.messagesTotal,
           threadsTotal: profile.threadsTotal,
-          historyId: profile.historyId,
           labelsTotal: profile.labelsTotal,
-          timestamp,
+          data: account,
+          createdAt: now,
+          updatedAt: now,
         });
-        // Store messages and threads if provided
+        
+        // Store messages and threads if provided (reusing same code as above)
         if (Array.isArray(messages)) {
           for (const msg of messages) {
-            const resourceId = msg.id || msg.messageId;
-            const existingMsg = await ctx.db
-              .query("gmailData")
-              .withIndex("by_resource_id", (q) => q.eq("resourceId", resourceId))
-              .filter((q) => 
-                q.eq(q.field("userId"), userId) && 
-                q.eq(q.field("email"), email) &&
-                q.eq(q.field("resourceType"), "message")
-              )
-              .first();
-            
-            if (existingMsg) {
-              // Update existing message
-              await ctx.db.patch(existingMsg._id, {
-                data: msg,
-                timestamp,
-              });
-            } else {
-              // Insert new message
-              await ctx.db.insert("gmailData", {
-                userId,
-                email,
-                resourceType: "message",
-                resourceId,
-                data: msg,
-                timestamp,
-              });
+            const messageId = msg.id || msg.messageId;
+            if (!messageId) {
+              console.warn(`Skipping message with undefined messageId: ${JSON.stringify(msg)}`);
+              continue;
             }
+            
+            const threadId = msg.threadId;
+            const from = msg.payload?.headers?.find((h: any) => h.name.toLowerCase() === 'from')?.value;
+            const subject = msg.payload?.headers?.find((h: any) => h.name.toLowerCase() === 'subject')?.value;
+            const snippet = msg.snippet || '';
+            
+            // No need to check for existing message since this is a new account
+            await ctx.db.insert("gmailMessages", {
+              userId,
+              email,
+              messageId,
+              threadId,
+              from,
+              subject,
+              snippet,
+              labelIds: msg.labelIds,
+              historyId: msg.historyId,
+              internalDate: msg.internalDate ? msg.internalDate.toString() : undefined,
+              sizeEstimate: msg.sizeEstimate,
+              data: msg,
+              createdAt: now,
+              updatedAt: now,
+            });
           }
         }
+        
         if (Array.isArray(threads)) {
           for (const thread of threads) {
-            const resourceId = thread.id || thread.threadId;
-            const existingThread = await ctx.db
-              .query("gmailData")
-              .withIndex("by_resource_id", (q) => q.eq("resourceId", resourceId))
-              .filter((q) => 
-                q.eq(q.field("userId"), userId) && 
-                q.eq(q.field("email"), email) &&
-                q.eq(q.field("resourceType"), "thread")
-              )
-              .first();
-            
-            if (existingThread) {
-              // Update existing thread
-              await ctx.db.patch(existingThread._id, {
-                data: thread,
-                timestamp,
-              });
-            } else {
-              // Insert new thread
-              await ctx.db.insert("gmailData", {
-                userId,
-                email,
-                resourceType: "thread",
-                resourceId,
-                data: thread,
-                timestamp,
-              });
+            const threadId = thread.id || thread.threadId;
+            if (!threadId) {
+              console.warn(`Skipping thread with undefined threadId: ${JSON.stringify(thread)}`);
+              continue;
             }
+            
+            // Extract messages from the thread if available
+            const threadMessages = thread.messages || [];
+            const message_count = threadMessages.length;
+            
+            // Map the messages to the correct format
+            const formattedMessages = threadMessages.map((m: any) => {
+              const from = m.payload?.headers?.find((h: any) => h.name.toLowerCase() === 'from')?.value;
+              const subject = m.payload?.headers?.find((h: any) => h.name.toLowerCase() === 'subject')?.value;
+              
+              return {
+                id: m.id,
+                from,
+                subject,
+                snippet: m.snippet,
+                label_ids: m.labelIds
+              };
+            });
+            
+            // No need to check for existing thread since this is a new account
+            await ctx.db.insert("gmailThreads", {
+              userId,
+              email,
+              threadId,
+              snippet: thread.snippet,
+              historyId: thread.historyId,
+              labelIds: thread.labelIds,
+              message_count,
+              messages: formattedMessages,
+              data: thread,
+              createdAt: now,
+              updatedAt: now,
+            });
           }
         }
+        
         return { status: "created", accountId };
       }
     } catch (error) {
@@ -526,16 +618,13 @@ export const saveProfileData = mutation({
   },
   handler: async (ctx, args) => {
     try {
-      const timestamp = Date.now();
+      const now = Date.now();
       
       // Check if the account already exists
       const existingAccount = await ctx.db
-        .query("gmailData")
-        .withIndex("by_resource_id", (q) => q.eq("resourceId", args.email))
-        .filter((q) => 
-          q.eq(q.field("userId"), args.userId) && 
-          q.eq(q.field("resourceType"), "account")
-        )
+        .query("gmailAccounts")
+        .withIndex("by_email", (q) => q.eq("email", args.email))
+        .filter(q => q.eq(q.field("userId"), args.userId))
         .first();
 
       if (existingAccount) {
@@ -545,16 +634,14 @@ export const saveProfileData = mutation({
           threadsTotal: args.profileData.threadsTotal,
           historyId: args.profileData.historyId,
           labelsTotal: args.profileData.labelsTotal,
-          timestamp,
+          updatedAt: now,
         });
         return { status: "updated", accountId: existingAccount._id };
       } else {
         // Create a new account entry if it does not exist
-        const accountId = await ctx.db.insert("gmailData", {
+        const accountId = await ctx.db.insert("gmailAccounts", {
           userId: args.userId,
-          email: args.email, // required for schema
-          resourceId: args.email, // for accounts, resourceId is the email
-          resourceType: "account",
+          email: args.email,
           messagesTotal: args.profileData.messagesTotal,
           threadsTotal: args.profileData.threadsTotal,
           historyId: args.profileData.historyId,
@@ -565,7 +652,8 @@ export const saveProfileData = mutation({
             historyId: args.profileData.historyId,
             labelsTotal: args.profileData.labelsTotal,
           },
-          timestamp,
+          createdAt: now,
+          updatedAt: now,
         });
         return { status: "created", accountId };
       }

--- a/convex/gmailQueries.ts
+++ b/convex/gmailQueries.ts
@@ -1,6 +1,7 @@
 // Written by Aria
 import { v } from "convex/values";
 import { query } from "./_generated/server";
+import { api } from "./_generated/api";
 
 // Get Gmail account data for a user
 export const getGmailAccounts = query({
@@ -8,11 +9,9 @@ export const getGmailAccounts = query({
   handler: async (ctx, args) => {
     try {
       const gmailAccounts = await ctx.db
-        .query("gmailData")
-        .withIndex("by_user", (q) => q.eq("userId", args.userId))
-        .filter((q) => q.eq(q.field("resourceType"), "account"))
+        .query("gmailAccounts")
+        .withIndex("by_userId", (q) => q.eq("userId", args.userId))
         .collect();
-
       return gmailAccounts;
     } catch (error) {
       console.error('Error getting Gmail accounts:', error);
@@ -27,11 +26,10 @@ export const getGmailAccountByEmail = query({
   handler: async (ctx, args) => {
     try {
       const gmailAccount = await ctx.db
-        .query("gmailData")
-        .withIndex("by_email", (q) => q.eq("userId", args.userId).eq("email", args.email))
-        .filter((q) => q.eq(q.field("resourceType"), "account"))
+        .query("gmailAccounts")
+        .withIndex("by_email", (q) => q.eq("email", args.email))
+        .filter((q) => q.eq(q.field("userId"), args.userId))
         .first();
-
       return gmailAccount;
     } catch (error) {
       console.error('Error getting Gmail account by email:', error);
@@ -61,19 +59,19 @@ export const getGmailToken = query({
 export const getGmailMessageById = query({
   args: { 
     userId: v.string(),
-    messageId: v.string()
+    email: v.string(), 
+    messageId: v.string() 
   },
   handler: async (ctx, args) => {
     try {
       const message = await ctx.db
-        .query("gmailData")
-        .withIndex("by_resource_id", (q) => q.eq("resourceId", args.messageId))
+        .query("gmailMessages")
+        .withIndex("by_messageId", (q) => q.eq("messageId", args.messageId))
         .filter((q) => 
           q.eq(q.field("userId"), args.userId) && 
-          q.eq(q.field("resourceType"), "message")
+          q.eq(q.field("email"), args.email)
         )
         .first();
-      
       return message;
     } catch (error) {
       console.error('Error getting Gmail message by ID:', error);
@@ -86,19 +84,19 @@ export const getGmailMessageById = query({
 export const getGmailThreadById = query({
   args: { 
     userId: v.string(),
-    threadId: v.string()
+    email: v.string(), 
+    threadId: v.string() 
   },
   handler: async (ctx, args) => {
     try {
       const thread = await ctx.db
-        .query("gmailData")
-        .withIndex("by_resource_id", (q) => q.eq("resourceId", args.threadId))
+        .query("gmailThreads")
+        .withIndex("by_threadId", (q) => q.eq("threadId", args.threadId))
         .filter((q) => 
           q.eq(q.field("userId"), args.userId) && 
-          q.eq(q.field("resourceType"), "thread")
+          q.eq(q.field("email"), args.email)
         )
         .first();
-      
       return thread;
     } catch (error) {
       console.error('Error getting Gmail thread by ID:', error);
@@ -111,23 +109,23 @@ export const getGmailThreadById = query({
 export const getGmailMessagesByThread = query({
   args: { 
     userId: v.string(),
-    threadId: v.string()
+    email: v.string(), 
+    threadId: v.string() 
   },
   handler: async (ctx, args) => {
     try {
       const messages = await ctx.db
-        .query("gmailData")
-        .withIndex("by_thread_id", (q) => q.eq("threadId", args.threadId))
+        .query("gmailMessages")
+        .withIndex("by_threadId", (q) => q.eq("threadId", args.threadId))
         .filter((q) => 
           q.eq(q.field("userId"), args.userId) && 
-          q.eq(q.field("resourceType"), "message")
+          q.eq(q.field("email"), args.email)
         )
         .collect();
-      
       return messages;
     } catch (error) {
-      console.error('Error getting Gmail messages by thread:', error);
-      throw new Error(`Failed to get Gmail messages by thread: ${error instanceof Error ? error.message : 'Unknown error'}`);
+      console.error('Error getting Gmail messages by thread ID:', error);
+      throw new Error(`Failed to get Gmail messages by thread ID: ${error instanceof Error ? error.message : 'Unknown error'}`);
     }
   },
 });
@@ -137,23 +135,24 @@ export const getRecentGmailMessages = query({
   args: { 
     userId: v.string(),
     email: v.optional(v.string()),
-    limit: v.optional(v.number())
+    limit: v.optional(v.number()),
   },
   handler: async (ctx, args) => {
     try {
-      let messagesQuery = ctx.db
-        .query("gmailData")
-        .withIndex("by_user_resource", (q) => 
-          q.eq("userId", args.userId).eq("resourceType", "message")
-        );
+      let query = ctx.db
+        .query("gmailMessages")
+        .withIndex("by_userId", (q) => q.eq("userId", args.userId));
       
+      // Filter by email if provided
       if (args.email) {
-        messagesQuery = messagesQuery.filter((q) => q.eq(q.field("email"), args.email));
+        query = query.filter((q) => q.eq(q.field("email"), args.email));
       }
       
-      const messages = await messagesQuery
-        .order("desc")
-        .take(args.limit || 50);
+      // Sort by updatedAt (newest first)
+      const sortedQuery = query.order("desc");
+      
+      // Apply limit if provided
+      const messages = await (args.limit ? sortedQuery.take(args.limit) : sortedQuery.collect());
       
       return messages;
     } catch (error) {
@@ -168,23 +167,24 @@ export const getRecentGmailThreads = query({
   args: { 
     userId: v.string(),
     email: v.optional(v.string()),
-    limit: v.optional(v.number())
+    limit: v.optional(v.number()),
   },
   handler: async (ctx, args) => {
     try {
-      let threadsQuery = ctx.db
-        .query("gmailData")
-        .withIndex("by_user_resource", (q) => 
-          q.eq("userId", args.userId).eq("resourceType", "thread")
-        );
+      let query = ctx.db
+        .query("gmailThreads")
+        .withIndex("by_userId", (q) => q.eq("userId", args.userId));
       
+      // Filter by email if provided
       if (args.email) {
-        threadsQuery = threadsQuery.filter((q) => q.eq(q.field("email"), args.email));
+        query = query.filter((q) => q.eq(q.field("email"), args.email));
       }
       
-      const threads = await threadsQuery
-        .order("desc")
-        .take(args.limit || 50);
+      // Sort by updatedAt (newest first)
+      const sortedQuery = query.order("desc");
+      
+      // Apply limit if provided
+      const threads = await (args.limit ? sortedQuery.take(args.limit) : sortedQuery.collect());
       
       return threads;
     } catch (error) {
@@ -194,32 +194,66 @@ export const getRecentGmailThreads = query({
   },
 });
 
-// Get Gmail data by resource type
-export const getGmailDataByType = query({
-  args: {
-    userId: v.string(),
-    resourceType: v.union(v.literal("message"), v.literal("thread")),
-    email: v.optional(v.string()),
-    limit: v.optional(v.number()),
-  },
+// List Gmail threads for content analytics page - compatible with UI components
+export const listUserGmailThreads = query({
+  args: { userId: v.string() },
   handler: async (ctx, args) => {
     try {
-      let query = ctx.db
-        .query("gmailData")
-        .withIndex("by_user_resource", (q) => 
-          q.eq("userId", args.userId).eq("resourceType", args.resourceType)
-        );
-      
-      if (args.email) {
-        query = query.filter((q) => q.eq(q.field("email"), args.email));
-      }
-      
-      return await query
+      // Fetch threads from the gmailThreads table
+      const threads = await ctx.db
+        .query("gmailThreads")
+        .withIndex("by_userId", (q) => q.eq("userId", args.userId))
         .order("desc")
-        .take(args.limit || 50);
+        .collect();
+      
+      // Transform threads to match the GmailContentItem format for UI
+      return threads.map(thread => {
+        // Extract the first message in the thread for display
+        const firstMessage = thread.messages && thread.messages.length > 0 ? thread.messages[0] : null;
+        
+        // Determine if this is a newsletter or regular email (basic logic - can be enhanced)
+        let emailType: 'newsletter' | 'partnership' | 'individual' | 'other' = 'individual';
+        const from = firstMessage?.from || thread.data?.from || '';
+        const subject = firstMessage?.subject || thread.data?.subject || 'No Subject';
+        
+        // Simple heuristic to guess email type - could be improved with more sophisticated logic
+        if (from.toLowerCase().includes('newsletter') || subject.toLowerCase().includes('newsletter')) {
+          emailType = 'newsletter';
+        } else if (from.toLowerCase().includes('partner') || subject.toLowerCase().includes('partner')) {
+          emailType = 'partnership';
+        } else if ((thread.message_count && thread.message_count > 3) || (thread.messages && thread.messages.length > 3)) {
+          // Longer threads are more likely to be individual conversations
+          emailType = 'individual';
+        } else {
+          emailType = 'other';
+        }
+        
+        return {
+          id: thread.threadId || '',
+          platform: 'gmail' as const,
+          publishedAt: thread.createdAt ? new Date(thread.createdAt).toISOString() : new Date().toISOString(),
+          content: {
+            subject: subject,
+            from: from,
+            snippet: thread.snippet || firstMessage?.snippet || '',
+            threadId: thread.threadId,
+            messageCount: thread.message_count || (thread.messages?.length || 0),
+            emailType: emailType, // Add required emailType property
+            // Use default value for recipients as it's optional in the interface
+            recipients: 1 // Default to 1 recipient
+          },
+          metrics: {
+            // These would normally come from Gmail analytics data
+            // For now, we'll use placeholders or default values
+            replies: thread.message_count ? thread.message_count - 1 : 0,
+            openRate: 0.75, // Placeholder
+            clickRate: 0.25, // Placeholder
+          }
+        };
+      });
     } catch (error) {
-      console.error(`Error getting Gmail ${args.resourceType}s:`, error);
-      throw new Error(`Failed to get Gmail ${args.resourceType}s: ${error instanceof Error ? error.message : 'Unknown error'}`);
+      console.error('Error listing Gmail threads:', error);
+      throw new Error(`Failed to list Gmail threads: ${error instanceof Error ? error.message : 'Unknown error'}`);
     }
   },
-}); 
+});

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -113,49 +113,84 @@ export default defineSchema({
     tokenType: v.string(),
   }).index("by_userId", ["userId"]),
 
-  // PLACEHOLDER Gmail Data - unified table for messages, threads, and accounts (change later, for data collection purposes)
-  gmailData: defineTable({
+  // Gmail Account Info
+  gmailAccounts: defineTable({
     userId: v.string(),
     email: v.string(),
-    resourceType: v.union(v.literal("message"), v.literal("thread"), v.literal("account")),
-    resourceId: v.optional(v.any()), // Either messageId, threadId, or email for accounts
-    threadId: v.optional(v.any()), // More flexible
-    snippet: v.optional(v.any()), // More flexible
-    historyId: v.optional(v.any()),
-    internalDate: v.optional(v.any()),
-    labelIds: v.optional(v.any()),
-    messages: v.optional(v.any()), // For threads: array of message IDs
-    data: v.any(), // Full message payload, thread data, or account data
-    sizeEstimate: v.optional(v.any()),
-    timestamp: v.number(), // When this record was created/updated
-    // Account specific fields
-    messagesTotal: v.optional(v.any()),
-    threadsTotal: v.optional(v.any()),
-    labelsTotal: v.optional(v.any()),
+    historyId: v.optional(v.string()),
+    messagesTotal: v.optional(v.number()),
+    threadsTotal: v.optional(v.number()),
+    labelsTotal: v.optional(v.union(v.number(), v.null())), // Make more flexible to handle null values
+    data: v.optional(v.any()), // Any additional account data
+    createdAt: v.number(),
+    updatedAt: v.number(),
   })
-  .index("by_user", ["userId"])
-  .index("by_email", ["userId", "email"])
-  .index("by_resource_type", ["resourceType"])
-  .index("by_resource_id", ["resourceId"])
-  .index("by_thread_id", ["threadId"])
-  .index("by_user_resource", ["userId", "resourceType"])
-  .index("by_timestamp", ["timestamp"]),
+  .index("by_userId", ["userId"])
+  .index("by_email", ["email"]),
 
-  // YouTube Data (placeholder, used for data collection purposes)
-  youtubeData: defineTable({
+  // Gmail Threads
+  gmailThreads: defineTable({
     userId: v.string(),
-    resourceType: v.union(v.literal("channel"), v.literal("video"), v.literal("video_analysis")),
-    data: v.any(),
-    timestamp: v.number(),
-    videoCount: v.optional(v.number()),
-    subscriberCount: v.optional(v.number()),
-    viewCount: v.optional(v.number()),
+    email: v.string(),
+    threadId: v.string(),
+    message_count: v.optional(v.number()),
+    messages: v.optional(v.array(v.object({
+      id: v.string(),
+      from: v.optional(v.string()),
+      subject: v.optional(v.string()),
+      snippet: v.optional(v.string()),
+      label_ids: v.optional(v.array(v.string())),
+    }))),
+    snippet: v.optional(v.string()),
+    historyId: v.optional(v.string()),
+    labelIds: v.optional(v.array(v.string())),
+    data: v.optional(v.any()), // Complete thread data
+    createdAt: v.number(),
+    updatedAt: v.number(),
   })
-  .index("by_user_resource", ["userId", "resourceType"])
-  .index("by_timestamp", ["timestamp"])
-  .index("by_user", ["userId"])
-  .index("by_resource_type", ["resourceType"]),
+  .index("by_userId", ["userId"])
+  .index("by_email", ["email"])
+  .index("by_threadId", ["threadId"])
+  .index("by_user_email", ["userId", "email"]),
 
+  // Gmail Messages
+  gmailMessages: defineTable({
+    userId: v.string(),
+    email: v.string(),
+    messageId: v.string(),
+    threadId: v.string(),
+    from: v.optional(v.string()),
+    subject: v.optional(v.string()),
+    snippet: v.optional(v.string()),
+    labelIds: v.optional(v.array(v.string())),
+    internalDate: v.optional(v.string()),
+    sizeEstimate: v.optional(v.number()),
+    historyId: v.optional(v.string()),
+    data: v.optional(v.any()), // Complete message data
+    createdAt: v.number(),
+    updatedAt: v.number(),
+  })
+  .index("by_userId", ["userId"])
+  .index("by_email", ["email"])
+  .index("by_messageId", ["messageId"])
+  .index("by_threadId", ["threadId"])
+  .index("by_user_email", ["userId", "email"]),
+
+  
+  // For storing Gmail push notifications history
+  gmailHistory: defineTable({
+    userId: v.string(),
+    email: v.string(),
+    historyId: v.string(),
+    timestamp: v.number(),
+    data: v.optional(v.any()), // History data from Gmail API
+    createdAt: v.number(),
+  })
+  .index("by_userId", ["userId"])
+  .index("by_email", ["email"])
+  .index("by_historyId", ["historyId"])
+  .index("by_timestamp", ["timestamp"]),
+  
   youtubeTokens: defineTable({
     userId: v.string(),
     accessToken: v.string(),


### PR DESCRIPTION
- Split unified gmailData table into specialized tables:
  - gmailAccounts: For account metadata
  - gmailThreads: For email threads
  - gmailMessages: For individual messages
  - gmailHistory: For push notification history
- Add proper email type classification in thread listing
- Improve error handling and logging
- Add proper timestamps and indexes