### PR TITLE
[feat] Implemented clickable chat suggestions

### DIFF
--- a/app/(dashboard)/_components/chat/ChatContainer.tsx
+++ b/app/(dashboard)/_components/chat/ChatContainer.tsx
@@ -218,13 +218,13 @@ const ChatContainer: React.FC<ChatScreenProps> = ({ chatId }) => {
                       onOptionClick={handleOptionClick}
                       onFollowUpClick={handleFollowUpClick}
                     />
-                    {message.role === 'assistant' && message.metadata?.suggestions && (
+                    {message.role === 'assistant' && message.suggestions && (
                       <div className="mt-3 flex flex-wrap gap-2 pl-12">
-                        {message.metadata.suggestions.map((suggestion, index) => (
+                        {message.suggestions.map((suggestion, index) => (
                           <SuggestionChip
                             key={index}
                             suggestion={suggestion}
-                            onClick={() => handleSuggestionClick(suggestion)}
+                            onClick={() => handleSuggestionClick(suggestion, handleSendMessage)}
                           />
                         ))}
                       </div>

--- a/app/(dashboard)/_components/chat/components/SuggestionChip.tsx
+++ b/app/(dashboard)/_components/chat/components/SuggestionChip.tsx
@@ -3,19 +3,28 @@ import { Brain, MessageSquare, Target, Zap } from 'lucide-react';
 import { SuggestedAction } from '../types';
 
 interface SuggestionChipProps {
-  suggestion: SuggestedAction;
+  suggestion: SuggestedAction | string;
   onClick: () => void;
 }
 
-export const SuggestionChip = ({ suggestion, onClick }: SuggestionChipProps) => (
-  <button
-    onClick={onClick}
-    className="px-3 py-1.5 text-sm bg-blue-50 hover:bg-blue-100 text-blue-700 rounded-full flex items-center gap-2 transition-colors"
-  >
-    {suggestion.type === 'explore' && <Brain className="w-4 h-4" />}
-    {suggestion.type === 'clarify' && <MessageSquare className="w-4 h-4" />}
-    {suggestion.type === 'action' && <Zap className="w-4 h-4" />}
-    {suggestion.type === 'strategic' && <Target className="w-4 h-4" />}
-    {suggestion.description}
-  </button>
-);
+export const SuggestionChip = ({ suggestion, onClick }: SuggestionChipProps) => {
+  // Handle both string suggestions and structured SuggestedAction objects
+  const isStringType = typeof suggestion === 'string';
+  
+  return (
+    <button
+      onClick={onClick}
+      className="px-3 py-1.5 text-sm bg-blue-50 hover:bg-blue-100 text-blue-700 rounded-full flex items-center gap-2 transition-colors"
+    >
+      {!isStringType && (
+        <>
+          {(suggestion as SuggestedAction).type === 'explore' && <Brain className="w-4 h-4" />}
+          {(suggestion as SuggestedAction).type === 'clarify' && <MessageSquare className="w-4 h-4" />}
+          {(suggestion as SuggestedAction).type === 'action' && <Zap className="w-4 h-4" />}
+          {(suggestion as SuggestedAction).type === 'strategic' && <Target className="w-4 h-4" />}
+        </>
+      )}
+      {isStringType ? suggestion : (suggestion as SuggestedAction).description}
+    </button>
+  );
+};

--- a/app/(dashboard)/_components/chat/hooks/useChat.ts
+++ b/app/(dashboard)/_components/chat/hooks/useChat.ts
@@ -72,6 +72,9 @@ export const useChat = (
       // Send message to the backend - pass isFirstMessage to ensure it's correctly flagged
       const data = await sendChatMessage(content, isFirstMessage, backendSessionId);
 
+      // Log the response to check structure
+      console.log('API response:', data);
+      
       // Update messages with the response
       setMessages(prev => {
         const withoutTyping = prev.filter(msg => msg.status !== 'typing');

--- a/app/(dashboard)/_components/chat/hooks/useUIEffects.ts
+++ b/app/(dashboard)/_components/chat/hooks/useUIEffects.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { Message } from '@/app/types/chat'
-import { AmbientInsight } from '../types'
+import { AmbientInsight, SuggestedAction } from '../types'
 
 export const useUIEffects = (
   messages: Message[],
@@ -40,11 +40,12 @@ export const useUIEffects = (
     onSendMessage(message)
   }, [])
 
-  const handleSuggestionClick = useCallback((suggestion: { description: string }) => {
-    if (inputRef.current) {
-      inputRef.current.value = suggestion.description
-      inputRef.current.focus()
-    }
+  const handleSuggestionClick = useCallback((suggestion: string | SuggestedAction, onSendMessage: (message: string) => void) => {
+    const message = typeof suggestion === 'string' 
+      ? suggestion 
+      : suggestion.description;
+    
+    onSendMessage(message);
   }, [])
 
   const handleRefresh = useCallback(async () => {


### PR DESCRIPTION
### 1. Summary of Changes  
This PR updates the chat UI to support flexible suggestion types and improves how suggestion chips trigger message sending. It introduces a dual-mode `SuggestionChip` component and enhances input handling to better support follow-up suggestions embedded directly in messages.

---

### 2. Key Changes  
The primary change in this PR is the transition from relying on `message.metadata.suggestions` to `message.suggestions` directly, which simplifies message structure and improves reliability when parsing suggestions on the frontend. The `SuggestionChip` component has been enhanced to handle both raw string suggestions and structured `SuggestedAction` objects. This allows the assistant to render suggestion chips from either format without failure.

Key updates include:
- Updated the `SuggestionChip` component to render properly whether it receives a plain string or a structured suggestion with a type and description. This prevents UI failures in cases where suggestions are returned in string form.
- Refactored `handleSuggestionClick` in `useUIEffects.ts` to accept both types of suggestions and immediately trigger message sending via `onSendMessage`.
- Updated `ChatContainer.tsx` to reflect the new field name `message.suggestions` and to pass the `handleSendMessage` function into the suggestion click handler.
- Added temporary logging in `useChat.ts` to inspect backend response formats during integration testing.

Notion Task: https://www.notion.so/Chat-Follow-Ups-1ed58668c71f80698e7cd07baefe9258

Reviewer: @ariaxhan 