### PR TITLE
Add endpoint to create new persona with validation and error handling

### DIFF
--- a/convex/http.ts
+++ b/convex/http.ts
@@ -72,6 +72,85 @@ app.get("/api/users/:id/personas", async (c) => {
   return c.json(persona);
 });
 
+// Create a new persona
+app.post("/api/users/:id/personas", async (c) => {
+  const ctx = c.env;
+  const userId = c.req.param("id");
+  const {
+    current_name,
+    current_description,
+    experience_level,
+    content_formats,
+    content_tone,
+    content_voice,
+    content_pillars,
+    unique_value,
+    future_name,
+    future_description,
+    goals,
+    desired_impact,
+    primary_topics,
+    secondary_topics,
+    tone_descriptors,
+    style_descriptors,
+    audience_type,
+    engagement_style
+  } = await c.req.json();
+
+  // Validate required fields
+  const missing = [];
+  if (!current_name) missing.push("current_name");
+  if (!current_description) missing.push("current_description");
+  if (!experience_level) missing.push("experience_level");
+  if (!Array.isArray(content_formats)) missing.push("content_formats");
+  if (!content_tone) missing.push("content_tone");
+  if (!content_voice) missing.push("content_voice");
+  if (!Array.isArray(content_pillars)) missing.push("content_pillars");
+  if (!unique_value) missing.push("unique_value");
+  if (!future_name) missing.push("future_name");
+  if (!future_description) missing.push("future_description");
+  if (!Array.isArray(goals)) missing.push("goals");
+  if (!desired_impact) missing.push("desired_impact");
+  if (!Array.isArray(primary_topics)) missing.push("primary_topics");
+  if (!Array.isArray(secondary_topics)) missing.push("secondary_topics");
+  if (!Array.isArray(tone_descriptors)) missing.push("tone_descriptors");
+  if (!Array.isArray(style_descriptors)) missing.push("style_descriptors");
+  if (!audience_type) missing.push("audience_type");
+  if (!Array.isArray(engagement_style)) missing.push("engagement_style");
+
+  if (missing.length > 0) {
+    return c.json({ success: false, error: `Missing required fields: ${missing.join(", ")}` }, 400);
+  }
+
+  try {
+    const result = await ctx.runMutation(api.personas.createPersona, {
+      userId,
+      current_name,
+      current_description,
+      experience_level,
+      content_formats,
+      content_tone,
+      content_voice,
+      content_pillars,
+      unique_value,
+      future_name,
+      future_description,
+      goals,
+      desired_impact,
+      primary_topics,
+      secondary_topics,
+      tone_descriptors,
+      style_descriptors,
+      audience_type,
+      engagement_style
+    });
+    return c.json({ success: true, personaId: result });
+  } catch (error) {
+    console.error("Failed to create persona:", error);
+    return c.json({ success: false, error: "Failed to create persona" }, 500);
+  }
+});
+
 // Conversations
 app.post("/api/users/:id/create_conversation", async (c) => {
   const ctx = c.env;


### PR DESCRIPTION
This pull request introduces a new API endpoint to create personas for users, enhancing the functionality of the `convex/http.ts` file. The addition includes validation for required fields, error handling, and integration with the persona creation mutation.

### New API Endpoint for Persona Creation:

* Added a `POST` endpoint at `/api/users/:id/personas` to allow users to create personas. The endpoint validates required fields, ensuring all necessary data is provided before proceeding with persona creation. Missing fields are reported back to the client with a `400` status code.
* Integrated the endpoint with the `api.personas.createPersona` mutation, passing all validated data for persona creation. On success, it returns the persona ID; on failure, it logs the error and responds with a `500` status code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability to create a new persona for a user via a new API endpoint. Users can specify various persona details, and the system will validate input and provide clear error messages for missing or invalid fields. On success, the new persona ID is returned.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->