### PR TITLE
Fetch posts by username instead of userID

### DIFF
--- a/src/app/dashboard/_components/content-analytics/components/ContentAnalyticsScreen.tsx
+++ b/src/app/dashboard/_components/content-analytics/components/ContentAnalyticsScreen.tsx
@@ -190,8 +190,10 @@ export function ContentAnalyticsScreen() {
     userId ? { userId } : undefined
   );
   const instagramPosts = useQuery(
-    api.instagramQueries.getAllInstagramPosts,
-    userId ? { userId } : undefined
+    // api.instagramQueries.getAllInstagramPosts,
+    // userId ? { userId } : undefined
+    api.instagramQueries.getInstagramPostsByUsername,
+    { username: "avasetail" } // Replace after testing
   );
 
   useEffect(() => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the method for fetching Instagram posts in the analytics screen to retrieve data by a fixed username instead of user ID.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->