### PR TITLE
Using accountID instead of userId to store posts

### DIFF
--- a/convex/instagramMutations.ts
+++ b/convex/instagramMutations.ts
@@ -13,7 +13,7 @@ export const storePostData = mutation({
   handler: async (ctx, args) => {
     const { userId, postId, postData } = args;
     const now = Date.now();
-    // accountId is not present in args, so set as empty string or adapt if available
+    // Get accountId from postData
     const accountId = postData.accountId || "";
 
     try {
@@ -21,14 +21,12 @@ export const storePostData = mutation({
       const existingPost = await ctx.db
         .query("instagramPosts")
         .withIndex("by_postId", q => q.eq("postId", postId))
-        .filter(q => q.eq(q.field("userId"), userId))
         .first();
 
       if (existingPost) {
         // Update existing post
         await ctx.db.patch(existingPost._id, {
           accountId,
-          userId,
           postId,
           data: {
             id: postId,
@@ -41,7 +39,6 @@ export const storePostData = mutation({
         // Insert new post
         const id = await ctx.db.insert("instagramPosts", {
           accountId,
-          userId,
           postId,
           data: {
             id: postId,

--- a/convex/instagramQueries.ts
+++ b/convex/instagramQueries.ts
@@ -62,9 +62,20 @@ export const getInstagramPost = query({
 export const getAllInstagramPosts = query({
   args: { userId: v.string() },
   handler: async (ctx, args) => {
+    // First get the account ID for this user
+    const account = await ctx.db
+      .query("instagramAccounts")
+      .withIndex("by_userId", q => q.eq("userId", args.userId))
+      .first();
+    
+    if (!account) {
+      return [];
+    }
+
+    // Then get all posts for this account
     const posts = await ctx.db
       .query("instagramPosts")
-      .withIndex("by_userId", q => q.eq("userId", args.userId))
+      .withIndex("by_accountId", q => q.eq("accountId", account.accountId))
       .order("desc")
       .collect();
     return posts;

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -457,7 +457,7 @@ export default defineSchema({
   // Instagram Posts
   instagramPosts: defineTable({
     accountId: v.any(),
-    userId: v.string(),
+    userId: v.optional(v.string()),
     postId: v.string(),
     data: v.object({
       id: v.string(),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the process for retrieving and displaying Instagram posts, ensuring posts are correctly associated with the appropriate account.
- **Refactor**
	- Updated data handling to use account information instead of user information for Instagram posts.
- **Chores**
	- Made the user ID field optional for Instagram posts, enhancing data flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->