### PR TITLE
Remove `userId` from Instagram GET Query Arguments in HTTP API

### DIFF
--- a/convex/http.ts
+++ b/convex/http.ts
@@ -817,7 +817,6 @@ app.get("/api/users/:id/instagram/profile/insights", async (c) => {
 
   try {
     const insights = await ctx.runQuery(api.instagramQueries.getProfileInsights, { 
-      userId,
       accountId
     });
     
@@ -853,7 +852,6 @@ app.get("/api/users/:id/instagram/stories", async (c) => {
 
   try {
     const stories = await ctx.runQuery(api.instagramQueries.getStories, { 
-      userId,
       accountId
     });
     
@@ -1230,7 +1228,6 @@ app.get("/api/users/:id/instagram/post/:postId", async (c) => {
 
   try {
     const post = await ctx.runQuery(api.instagramQueries.getInstagramPost, { 
-      userId,
       postId
     });
     
@@ -1262,7 +1259,6 @@ app.get("/api/users/:id/instagram/post/:postId/insights", async (c) => {
 
   try {
     const post = await ctx.runQuery(api.instagramQueries.getInstagramPost, { 
-      userId,
       postId
     });
     
@@ -1301,7 +1297,6 @@ app.get("/api/users/:id/instagram/post/:postId/comments", async (c) => {
 
   try {
     const post = await ctx.runQuery(api.instagramQueries.getInstagramPost, { 
-      userId,
       postId
     });
     


### PR DESCRIPTION

### Summary

This PR updates the backend HTTP API to remove the unnecessary `userId` property from Convex query calls for Instagram GET endpoints. This resolves TypeScript errors and aligns the API calls with the expected query signatures.

---

### Changes

- Removed `userId` from the argument object in the following HTTP endpoints:
  - `/api/users/:id/instagram/profile/insights`
  - `/api/users/:id/instagram/stories`
  - `/api/users/:id/instagram/post/:postId`
  - `/api/users/:id/instagram/post/:postId/insights`
  - `/api/users/:id/instagram/post/:postId/comments`
- Now only the required properties (e.g., `accountId`, `postId`) are passed to the corresponding Convex queries.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Instagram data retrieval endpoints to enhance reliability and consistency when accessing user profile insights, stories, posts, post insights, and comments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->