### PR TITLE
Adding back userID for posts storage

### DIFF
--- a/convex/instagramMutations.ts
+++ b/convex/instagramMutations.ts
@@ -26,6 +26,7 @@ export const storePostData = mutation({
       if (existingPost) {
         // Update existing post
         await ctx.db.patch(existingPost._id, {
+          userId,
           accountId,
           postId,
           data: {
@@ -38,6 +39,7 @@ export const storePostData = mutation({
       } else {
         // Insert new post
         const id = await ctx.db.insert("instagramPosts", {
+          userId,
           accountId,
           postId,
           data: {

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -459,7 +459,7 @@ export default defineSchema({
   // Instagram Posts
   instagramPosts: defineTable({
     accountId: v.any(),
-    userId: v.optional(v.string()),
+    userId: v.string(),
     postId: v.string(),
     data: v.object({
       id: v.string(),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Ensured that the user ID is now always stored with Instagram posts.
- **Refactor**
	- Updated Instagram post data requirements so that a user ID must always be present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->