### PR TITLE
[refactor] Rename accountId to instagramAccountId for Instagram integration

### DIFF
--- a/convex/http.ts
+++ b/convex/http.ts
@@ -726,7 +726,7 @@ try {
 app.post("/api/users/:id/instagram/token", async (c) => {
 const ctx = c.env;
 const userId = c.req.param("id");
-const { accountId, accessToken, refreshToken, expiresAt, scope } = await c.req.json();
+const { instagramAccountId, accessToken, refreshToken, expiresAt, scope } = await c.req.json();
 
 // Ensure scope is an array of strings
 const scopeArray = Array.isArray(scope)
@@ -738,11 +738,11 @@ const scopeArray = Array.isArray(scope)
 try {
     await ctx.runMutation(api.instagramMutations.updateInstagramToken, {
     userId,
-    accountId,
-    accessToken,
-    refreshToken,
-    expiresAt,
-    scope: scopeArray,
+    instagramAccountId,
+    accessToken: accessToken as string,
+    refreshToken: refreshToken as string,
+    expiresAt: expiresAt as number,
+    scope: scopeArray as string[],
     });
     return c.json({ success: true });
 } catch (error) {
@@ -753,60 +753,73 @@ try {
 
 // Store Instagram posts in bulk
 app.post("/api/users/:id/instagram/posts/bulk", async (c) => {
-const ctx = c.env;
-const userId = c.req.param("id");
-const { posts } = await c.req.json();
+  const ctx = c.env;
+  const userId = c.req.param("id");
+  const { instagramAccountId, posts } = await c.req.json();
 
-if (!Array.isArray(posts) || posts.length === 0) {
+  if (!Array.isArray(posts) || posts.length === 0) {
     return c.json({ success: false, error: "No posts provided" }, 400);
-}
+  }
 
-const results = [];
-for (const post of posts) {
+  if (!instagramAccountId) {
+    return c.json({ success: false, error: "Missing instagramAccountId" }, 400);
+  }
+
+  const results = [];
+  for (const post of posts) {
     if (!post.id) {
-    results.push({ status: "error", error: "Missing post id", post });
-    continue;
+      results.push({ status: "error", error: "Missing post id", post });
+      continue;
     }
     try {
-    const result = await ctx.runMutation(api.instagramMutations.storePostData, {
+      const result = await ctx.runMutation(api.instagramMutations.storePostData, {
         userId,
         postId: post.id,
+        instagramAccountId,
         postData: post,
-    });
-    results.push({ status: result.status, postId: post.id });
+      });
+      results.push({ status: result.status, postId: post.id });
     } catch (error) {
-    results.push({ status: "error", error: error instanceof Error ? error.message : "Unknown error", postId: post.id });
+      results.push({ status: "error", error: error instanceof Error ? error.message : "Unknown error", postId: post.id });
     }
-}
+  }
 
-return c.json({ success: true, results });
+  return c.json({ success: true, results });
 });
 
 // Store Instagram profile data
 app.post("/api/users/:id/instagram/profile", async (c) => {
 const ctx = c.env;
 const userId = c.req.param("id");
-const { username, accountId, profileData, createdAt, updatedAt } = await c.req.json();
+const { username, instagramAccountId, profileData, createdAt, updatedAt } = await c.req.json();
 
 // Validate required fields
-if (!profileData || !profileData.id || !username || !accountId) {
-    return c.json({ success: false, error: "profileData.id, accountId, and username are required" }, 400);
+if (!profileData || !profileData.id || !username || !instagramAccountId) {
+    return c.json({ success: false, error: "profileData.id, instagramAccountId, and username are required" }, 400);
 }
 
 try {
     const result = await ctx.runMutation(api.instagramMutations.storeProfileData, {
     userId,
-    accountId,
-    username,
-    profileData,
-    createdAt: createdAt ?? Date.now(),
-    updatedAt: updatedAt ?? Date.now(),
+    instagramAccountId,
+    username: username as string,
+    profileData: profileData as {
+        id: string;
+        username: string;
+        account_type: any;
+        profile_picture_url: any;
+        followers_count: any;
+        follows_count: any;
+        media_count: any;
+    },
+    createdAt: (createdAt ?? Date.now()) as number,
+    updatedAt: (updatedAt ?? Date.now()) as number,
     });
 
     return c.json({ 
     success: true,
     status: result.status,
-    accountId: result.accountId,
+    instagramAccountId: result.instagramAccountId,
     });
 } catch (error) {
     console.error("Failed to store Instagram profile data:", error);
@@ -821,16 +834,16 @@ try {
 app.get("/api/users/:id/instagram/profile/insights", async (c) => {
   const ctx = c.env;
   const userId = c.req.param("id");
-  const accountId = c.req.query("accountId");
+  const instagramAccountId = c.req.query("instagramAccountId");
 
-  if (!accountId) {
-    return c.json({ success: false, error: "Missing accountId query parameter" }, 400);
+  if (!instagramAccountId) {
+    return c.json({ success: false, error: "Missing instagramAccountId query parameter" }, 400);
   }
 
   try {
     const insights = await ctx.runQuery(api.instagramQueries.getProfileInsights, { 
       userId,
-      accountId
+      instagramAccountId
     });
     
     if (!insights) {
@@ -857,16 +870,16 @@ app.get("/api/users/:id/instagram/profile/insights", async (c) => {
 app.get("/api/users/:id/instagram/stories", async (c) => {
   const ctx = c.env;
   const userId = c.req.param("id");
-  const accountId = c.req.query("accountId");
+  const instagramAccountId = c.req.query("instagramAccountId");
 
-  if (!accountId) {
-    return c.json({ success: false, error: "Missing accountId query parameter" }, 400);
+  if (!instagramAccountId) {
+    return c.json({ success: false, error: "Missing instagramAccountId query parameter" }, 400);
   }
 
   try {
     const stories = await ctx.runQuery(api.instagramQueries.getStories, { 
       userId,
-      accountId
+      instagramAccountId
     });
     
     if (!stories) {
@@ -893,16 +906,16 @@ app.get("/api/users/:id/instagram/stories", async (c) => {
 app.post("/api/users/:id/instagram/profile/insights", async (c) => {
   const ctx = c.env;
   const userId = c.req.param("id");
-  const { accountId, insightsData } = await c.req.json();
+  const { instagramAccountId, insightsData } = await c.req.json();
 
-  if (!accountId || !insightsData) {
+  if (!instagramAccountId || !insightsData) {
     return c.json({ success: false, error: "Missing required fields" }, 400);
   }
 
   try {
     const result = await ctx.runMutation(api.instagramMutations.storeProfileInsights, {
       userId,
-      accountId,
+      instagramAccountId,
       insightsData,
       createdAt: Date.now(),
       updatedAt: Date.now()
@@ -925,16 +938,16 @@ app.post("/api/users/:id/instagram/profile/insights", async (c) => {
 app.post("/api/users/:id/instagram/stories", async (c) => {
   const ctx = c.env;
   const userId = c.req.param("id");
-  const { accountId, storiesData } = await c.req.json();
+  const { instagramAccountId, storiesData } = await c.req.json();
 
-  if (!accountId || !storiesData) {
+  if (!instagramAccountId || !storiesData) {
     return c.json({ success: false, error: "Missing required fields" }, 400);
   }
 
   try {
     const result = await ctx.runMutation(api.instagramMutations.storeStories, {
       userId,
-      accountId,
+      instagramAccountId,
       storiesData,
       createdAt: Date.now(),
       updatedAt: Date.now()

--- a/convex/instagramMutations.ts
+++ b/convex/instagramMutations.ts
@@ -8,13 +8,12 @@ export const storePostData = mutation({
   args: {
     userId: v.string(),
     postId: v.string(),
+    instagramAccountId: v.string(),
     postData: v.any(),
   },
   handler: async (ctx, args) => {
-    const { userId, postId, postData } = args;
+    const { userId, postId, instagramAccountId, postData } = args;
     const now = Date.now();
-    // Get accountId from postData
-    const accountId = postData.accountId || "";
 
     try {
       // Convert ISO timestamp to Unix timestamp if present
@@ -34,7 +33,7 @@ export const storePostData = mutation({
       if (existingPost) {
         // Update existing post
         await ctx.db.patch(existingPost._id, {
-          accountId,
+          instagramAccountId,
           postId,
           data: {
             id: postId,
@@ -47,7 +46,7 @@ export const storePostData = mutation({
         // Insert new post
         const id = await ctx.db.insert("instagramPosts", {
           userId,
-          accountId,
+          instagramAccountId,
           postId,
           data: {
             id: postId,
@@ -59,8 +58,8 @@ export const storePostData = mutation({
         return { status: "created", postId: id };
       }
     } catch (error) {
-      console.error(`Error storing post data for ${postId}:`, error);
-      throw new Error(`Failed to store post data: ${error instanceof Error ? error.message : 'Unknown error'}`);
+      console.error(`Error storing Instagram post ${postId}:`, error);
+      throw new Error(`Failed to store Instagram post: ${error instanceof Error ? error.message : 'Unknown error'}`);
     }
   },
 });
@@ -69,7 +68,7 @@ export const storePostData = mutation({
 export const storeProfileData = mutation({
   args: {
     userId: v.string(),
-    accountId: v.any(),
+    instagramAccountId: v.string(),
     username: v.string(),
     profileData: v.object({
       id: v.string(),
@@ -84,7 +83,7 @@ export const storeProfileData = mutation({
     updatedAt: v.number(),
   },
   handler: async (ctx, args) => {
-    const { userId, accountId, username, profileData, createdAt, updatedAt } = args;
+    const { userId, instagramAccountId, username, profileData, createdAt, updatedAt } = args;
     try {
       // Check if account already exists
       const existingAccount = await ctx.db
@@ -94,21 +93,21 @@ export const storeProfileData = mutation({
       if (existingAccount) {
         await ctx.db.patch(existingAccount._id, {
           username,
-          accountId,
+          instagramAccountId: String(instagramAccountId),
           profileData,
           updatedAt,
         });
-        return { status: "updated", accountId: existingAccount._id };
+        return { status: "updated", instagramAccountId: String(instagramAccountId) };
       } else {
         const id = await ctx.db.insert("instagramAccounts", {
           userId,
-          accountId,
+          instagramAccountId: String(instagramAccountId),
           username,
           profileData,
           createdAt,
           updatedAt,
         });
-        return { status: "created", accountId: id };
+        return { status: "created", instagramAccountId: String(instagramAccountId) };
       }
     } catch (error) {
       console.error(`Error storing Instagram account for user ${userId}:`, error);
@@ -121,7 +120,7 @@ export const storeProfileData = mutation({
 export const updateInstagramToken = mutation({
   args: {
     userId: v.string(),
-    accountId: v.any(),
+    instagramAccountId: v.string(),
     accessToken: v.string(),
     refreshToken: v.string(),
     expiresAt: v.number(),
@@ -135,7 +134,7 @@ export const updateInstagramToken = mutation({
       .first();
     if (existing) {
       await ctx.db.patch(existing._id, {
-        accountId: args.accountId,
+        instagramAccountId: String(args.instagramAccountId),
         accessToken: args.accessToken,
         refreshToken: args.refreshToken,
         expiryDate: args.expiresAt,
@@ -144,7 +143,7 @@ export const updateInstagramToken = mutation({
       });
     } else {
       await ctx.db.insert("instagramTokens", {
-        accountId: args.accountId,
+        instagramAccountId: String(args.instagramAccountId),
         userId: args.userId,
         accessToken: args.accessToken,
         refreshToken: args.refreshToken,
@@ -212,7 +211,7 @@ export const disconnectInstagram = mutation({
 export const storeProfileInsights = mutation({
   args: {
     userId: v.string(),
-    accountId: v.any(),
+    instagramAccountId: v.string(),
     insightsData: v.object({
       impressions: v.optional(v.number()),
       reach: v.optional(v.number()),
@@ -229,7 +228,7 @@ export const storeProfileInsights = mutation({
     updatedAt: v.optional(v.number()),
   },
   handler: async (ctx, args) => {
-    const { userId, accountId, insightsData, createdAt, updatedAt } = args;
+    const { userId, instagramAccountId, insightsData, createdAt, updatedAt } = args;
     const now = Date.now();
 
     try {
@@ -237,7 +236,7 @@ export const storeProfileInsights = mutation({
       const existingInsights = await ctx.db
         .query("instagramProfileInsights")
         .withIndex("by_userId", q => q.eq("userId", userId))
-        .filter(q => q.eq(q.field("accountId"), accountId))
+        .filter(q => q.eq(q.field("instagramAccountId"), String(instagramAccountId)))
         .first();
 
       if (existingInsights) {
@@ -251,7 +250,7 @@ export const storeProfileInsights = mutation({
         // Insert new insights
         const id = await ctx.db.insert("instagramProfileInsights", {
           userId,
-          accountId,
+          instagramAccountId: String(instagramAccountId),
           data: insightsData,
           createdAt: createdAt ?? now,
           updatedAt: updatedAt ?? now,
@@ -269,7 +268,7 @@ export const storeProfileInsights = mutation({
 export const storeStories = mutation({
   args: {
     userId: v.string(),
-    accountId: v.any(),
+    instagramAccountId: v.string(),
     storiesData: v.array(v.object({
       id: v.string(),
       media_type: v.string(),
@@ -294,7 +293,7 @@ export const storeStories = mutation({
     updatedAt: v.optional(v.number()),
   },
   handler: async (ctx, args) => {
-    const { userId, accountId, storiesData, createdAt, updatedAt } = args;
+    const { userId, instagramAccountId, storiesData, createdAt, updatedAt } = args;
     const now = Date.now();
 
     try {
@@ -302,7 +301,7 @@ export const storeStories = mutation({
       const existingStories = await ctx.db
         .query("instagramStories")
         .withIndex("by_userId", q => q.eq("userId", userId))
-        .filter(q => q.eq(q.field("accountId"), accountId))
+        .filter(q => q.eq(q.field("instagramAccountId"), String(instagramAccountId)))
         .first();
 
       if (existingStories) {
@@ -316,7 +315,7 @@ export const storeStories = mutation({
         // Insert new stories
         const id = await ctx.db.insert("instagramStories", {
           userId,
-          accountId,
+          instagramAccountId: String(instagramAccountId),
           data: storiesData,
           createdAt: createdAt ?? now,
           updatedAt: updatedAt ?? now,

--- a/convex/instagramQueries.ts
+++ b/convex/instagramQueries.ts
@@ -22,7 +22,7 @@ export const getInstagramAccount = query({
     console.log('Found account:', accounts ? {
       userId: accounts.userId,
       username: accounts.username,
-      accountId: accounts.accountId
+      instagramAccountId: accounts.instagramAccountId
     } : 'No account found');
     
     return accounts;
@@ -72,23 +72,25 @@ export const getAllInstagramPosts = query({
       return [];
     }
 
-    // Then get all posts for this account
+    // Then get all posts for this account using both userId and instagramAccountId
     const posts = await ctx.db
       .query("instagramPosts")
-      .withIndex("by_accountId", q => q.eq("accountId", account.accountId))
+      .withIndex("by_instagramAccountId", q => q.eq("instagramAccountId", account.instagramAccountId))
+      .filter(q => q.eq(q.field("userId"), args.userId))
       .order("desc")
       .collect();
     return posts;
   },
 });
 
-// Get all Instagram posts for an accountId
+// Get all Instagram posts for an instagramAccountId
 export const getInstagramPostsByAccount = query({
-  args: { accountId: v.string() },
+  args: { userId: v.string(), instagramAccountId: v.string() },
   handler: async (ctx, args) => {
     const posts = await ctx.db
       .query("instagramPosts")
-      .withIndex("by_accountId", q => q.eq("accountId", args.accountId))
+      .withIndex("by_instagramAccountId", q => q.eq("instagramAccountId", args.instagramAccountId))
+      .filter(q => q.eq(q.field("userId"), args.userId))
       .order("desc")
       .collect();
     return posts;
@@ -99,9 +101,20 @@ export const getInstagramPostsByAccount = query({
 export const getInstagramPostsByTimeRange = query({
   args: { userId: v.string(), start: v.number(), end: v.number() },
   handler: async (ctx, args) => {
+    // First get the account ID for this user
+    const account = await ctx.db
+      .query("instagramAccounts")
+      .withIndex("by_userId", q => q.eq("userId", args.userId))
+      .first();
+    
+    if (!account) {
+      return [];
+    }
+
     const posts = await ctx.db
       .query("instagramPosts")
-      .withIndex("by_userId", q => q.eq("userId", args.userId))
+      .withIndex("by_instagramAccountId", q => q.eq("instagramAccountId", account.instagramAccountId))
+      .filter(q => q.eq(q.field("userId"), args.userId))
       .filter(q => q.gte(q.field("data.timestamp"), args.start))
       .filter(q => q.lte(q.field("data.timestamp"), args.end))
       .order("desc")
@@ -114,9 +127,20 @@ export const getInstagramPostsByTimeRange = query({
 export const getLatestInstagramPost = query({
   args: { userId: v.string() },
   handler: async (ctx, args) => {
+    // First get the account ID for this user
+    const account = await ctx.db
+      .query("instagramAccounts")
+      .withIndex("by_userId", q => q.eq("userId", args.userId))
+      .first();
+    
+    if (!account) {
+      return null;
+    }
+
     const post = await ctx.db
       .query("instagramPosts")
-      .withIndex("by_userId", q => q.eq("userId", args.userId))
+      .withIndex("by_instagramAccountId", q => q.eq("instagramAccountId", account.instagramAccountId))
+      .filter(q => q.eq(q.field("userId"), args.userId))
       .order("desc")
       .first();
     return post;
@@ -125,10 +149,22 @@ export const getLatestInstagramPost = query({
 
 // Get posts by username
 export const getInstagramPostsByUsername = query({
-  args: { username: v.string() },
+  args: { userId: v.string(), username: v.string() },
   handler: async (ctx, args) => {
+    // First get the account ID for this user
+    const account = await ctx.db
+      .query("instagramAccounts")
+      .withIndex("by_userId", q => q.eq("userId", args.userId))
+      .first();
+    
+    if (!account) {
+      return [];
+    }
+
     const posts = await ctx.db
       .query("instagramPosts")
+      .withIndex("by_instagramAccountId", q => q.eq("instagramAccountId", account.instagramAccountId))
+      .filter(q => q.eq(q.field("userId"), args.userId))
       .filter(q => q.eq(q.field("data.username"), args.username))
       .order("desc")
       .collect();
@@ -140,16 +176,16 @@ export const getInstagramPostsByUsername = query({
 export const getProfileInsights = query({
   args: {
     userId: v.string(),
-    accountId: v.any(),
+    instagramAccountId: v.string(),
   },
   handler: async (ctx, args) => {
-    const { userId, accountId } = args;
+    const { userId, instagramAccountId } = args;
 
     try {
       const insights = await ctx.db
         .query("instagramProfileInsights")
         .withIndex("by_userId", q => q.eq("userId", userId))
-        .filter(q => q.eq(q.field("accountId"), accountId))
+        .filter(q => q.eq(q.field("instagramAccountId"), String(instagramAccountId)))
         .first();
 
       return insights?.data || null;
@@ -164,16 +200,16 @@ export const getProfileInsights = query({
 export const getStories = query({
   args: {
     userId: v.string(),
-    accountId: v.any(),
+    instagramAccountId: v.string(),
   },
   handler: async (ctx, args) => {
-    const { userId, accountId } = args;
+    const { userId, instagramAccountId } = args;
 
     try {
       const stories = await ctx.db
         .query("instagramStories")
         .withIndex("by_userId", q => q.eq("userId", userId))
-        .filter(q => q.eq(q.field("accountId"), accountId))
+        .filter(q => q.eq(q.field("instagramAccountId"), String(instagramAccountId)))
         .first();
 
       return stories?.data || null;
@@ -194,6 +230,17 @@ export const getPostInsights = query({
     const { userId, postId } = args;
 
     try {
+      // First get the post to verify ownership
+      const post = await ctx.db
+        .query("instagramPosts")
+        .withIndex("by_postId", q => q.eq("postId", postId))
+        .filter(q => q.eq(q.field("userId"), userId))
+        .first();
+
+      if (!post) {
+        return null;
+      }
+
       const insights = await ctx.db
         .query("instagramPostInsights")
         .withIndex("by_postId", q => q.eq("postId", postId))
@@ -218,6 +265,17 @@ export const getPostComments = query({
     const { userId, postId } = args;
 
     try {
+      // First get the post to verify ownership
+      const post = await ctx.db
+        .query("instagramPosts")
+        .withIndex("by_postId", q => q.eq("postId", postId))
+        .filter(q => q.eq(q.field("userId"), userId))
+        .first();
+
+      if (!post) {
+        return null;
+      }
+
       const comments = await ctx.db
         .query("instagramPostComments")
         .withIndex("by_postId", q => q.eq("postId", postId))

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -428,7 +428,7 @@ export default defineSchema({
   // Instagram Tokens
   instagramTokens: defineTable({
     userId: v.string(),
-    accountId: v.any(),
+    instagramAccountId: v.string(),
     accessToken: v.string(),
     refreshToken: v.string(),
     expiryDate: v.number(),
@@ -439,7 +439,7 @@ export default defineSchema({
   // Instagram Accounts
   instagramAccounts: defineTable({
     userId: v.string(),
-    accountId: v.any(),    
+    instagramAccountId: v.string(),    
     username: v.string(),
     profileData: v.object({
       id: v.string(),
@@ -458,7 +458,7 @@ export default defineSchema({
 
   // Instagram Posts
   instagramPosts: defineTable({
-    accountId: v.any(),
+    instagramAccountId: v.string(),
     userId: (v.string()),
     postId: v.string(),
     data: v.object({
@@ -487,7 +487,7 @@ export default defineSchema({
     createdAt: v.number(),
     updatedAt: v.number(),
   })
-  .index("by_accountId", ["accountId"])
+  .index("by_instagramAccountId", ["instagramAccountId"])
   .index("by_userId", ["userId"])
   .index("by_postId", ["postId"])
   .index("by_timestamp", ["data.timestamp"]),
@@ -495,7 +495,7 @@ export default defineSchema({
   // Instagram Profile Insights
   instagramProfileInsights: defineTable({
     userId: v.string(),
-    accountId: v.any(),
+    instagramAccountId: v.string(),
     data: v.object({
       impressions: v.optional(v.number()),
       reach: v.optional(v.number()),
@@ -513,13 +513,13 @@ export default defineSchema({
     updatedAt: v.number(),
   })
   .index("by_userId", ["userId"])
-  .index("by_accountId", ["accountId"])
+  .index("by_instagramAccountId", ["instagramAccountId"])
   .index("by_timestamp", ["data.timestamp"]),
 
   // Instagram Stories
   instagramStories: defineTable({
     userId: v.string(),
-    accountId: v.any(),
+    instagramAccountId: v.string(),
     data: v.array(v.object({
       id: v.string(),
       media_type: v.string(),
@@ -544,7 +544,7 @@ export default defineSchema({
     updatedAt: v.number(),
   })
   .index("by_userId", ["userId"])
-  .index("by_accountId", ["accountId"]),
+  .index("by_instagramAccountId", ["instagramAccountId"]),
 
   // Instagram Post Insights
   instagramPostInsights: defineTable({


### PR DESCRIPTION
## Summary of Changes

This pull request refactors the Instagram integration to improve data consistency and clarity. It replaces the generic `accountId` field with the more specific `instagramAccountId` across the database schema, queries, and mutations. This change enhances code readability and reduces the risk of conflicts with other account types in the future.

## Key Changes

This PR aims to improve the maintainability and scalability of the Instagram integration by renaming the `accountId` field to `instagramAccountId`.

The primary change involves updating the database schema in `convex/schema.ts` to use `instagramAccountId` for storing Instagram-related data. Correspondingly, queries in `convex/instagramQueries.ts` and mutations in `convex/http.ts` have been modified to reflect this change. This renaming provides several benefits: it clarifies the purpose of the field, reduces the potential for naming collisions with other social media integrations, and improves the overall organization of the codebase. By using a more descriptive name, we enhance code readability and make it easier for developers to understand and maintain the Instagram integration in the long term.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Standardized the naming of Instagram account identifiers to use "instagramAccountId" across all Instagram-related features for improved clarity and consistency.
	- Updated relevant queries and mutations to use the new identifier.
	- Adjusted database schema fields and indexes to match the updated naming convention.
- **Bug Fixes**
	- Added ownership validation to certain Instagram post queries to enhance data security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->