### PR TITLE
changed title to stop re-rendering the entire time

### DIFF
--- a/src/app/dashboard/_components/smart-notes/NoteArea.tsx
+++ b/src/app/dashboard/_components/smart-notes/NoteArea.tsx
@@ -37,6 +37,7 @@ export function NoteArea({
   // Local UI state
   const [activeTab, setActiveTab] = useState<string>("editor");
   const editorRef = useRef<HTMLTextAreaElement>(null);
+  const [isEditingTitle, setIsEditingTitle] = useState(false);
   
   // Add event listener to switch to editor tab when an idea is applied
   React.useEffect(() => {
@@ -74,7 +75,8 @@ export function NoteArea({
     onUpdate,
     onSave,
     onToggleShortcuts,
-    onRequestAIInsights
+    onRequestAIInsights,
+    isEditingTitle
   });
 
   // Track the latest title from NoteMeta
@@ -109,6 +111,7 @@ export function NoteArea({
         note={note}
         onUpdate={onUpdate}
         onTitleChange={handleMetaTitleChange}
+        onEditingTitleChange={setIsEditingTitle}
       />
       
       {/* Main content area with tabs */}

--- a/src/app/dashboard/_components/smart-notes/components/NoteMeta.tsx
+++ b/src/app/dashboard/_components/smart-notes/components/NoteMeta.tsx
@@ -6,21 +6,22 @@ interface NoteMetaProps {
   note: Note;
   onUpdate: (noteId: string, updates: { title: string }) => Promise<Note>;
   onTitleChange?: (title: string) => void;
+  onEditingTitleChange?: (isEditing: boolean) => void;
 }
 
-export function NoteMeta({ note, onUpdate, onTitleChange }: NoteMetaProps) {
+export function NoteMeta({ note, onUpdate, onTitleChange, onEditingTitleChange }: NoteMetaProps) {
   const [title, setTitle] = useState(note.title || "Untitled Note");
   const [isEditing, setIsEditing] = useState(false);
   
   // Update local title state when note prop changes
   useEffect(() => {
-    setTitle(note.title || "Untitled Note");
-    console.log('[NoteMeta] Rendering title:', note.title);
-    if (onTitleChange) {
-      onTitleChange(note.title || "Untitled Note");
-      console.log('[NoteMeta] useEffect: called onTitleChange with', note.title || "Untitled Note");
+    if (!isEditing) {
+      setTitle(note.title || "Untitled Note");
+      if (onTitleChange) {
+        onTitleChange(note.title || "Untitled Note");
+      }
     }
-  }, [note._id, note.title, onTitleChange]);
+  }, [note._id, note.title, onTitleChange, isEditing]);
 
   const handleTitleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setTitle(e.target.value);
@@ -30,6 +31,10 @@ export function NoteMeta({ note, onUpdate, onTitleChange }: NoteMetaProps) {
     }
   };
 
+  const handleTitleFocus = () => {
+    setIsEditing(true);
+    if (onEditingTitleChange) onEditingTitleChange(true);
+  };
 
   const handleTitleBlur = async () => {
     if (title !== note.title) {
@@ -37,6 +42,7 @@ export function NoteMeta({ note, onUpdate, onTitleChange }: NoteMetaProps) {
       await onUpdate(String(note._id), { title });
     }
     setIsEditing(false);
+    if (onEditingTitleChange) onEditingTitleChange(false);
   };
 
   const handleTitleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
@@ -52,6 +58,7 @@ export function NoteMeta({ note, onUpdate, onTitleChange }: NoteMetaProps) {
           type="text"
           value={title}
           onChange={handleTitleChange}
+          onFocus={handleTitleFocus}
           onBlur={handleTitleBlur}
           onKeyDown={handleTitleKeyDown}
           className="w-full text-xl font-semibold px-2 py-1 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-purple-300"
@@ -60,7 +67,7 @@ export function NoteMeta({ note, onUpdate, onTitleChange }: NoteMetaProps) {
       ) : (
         <h1 
           className="text-xl font-semibold px-2 py-1 hover:bg-gray-50 rounded-md cursor-pointer"
-          onClick={() => setIsEditing(true)}
+          onClick={() => { setIsEditing(true); if (onEditingTitleChange) onEditingTitleChange(true); }}
         >
           {title || "Untitled Note"}
         </h1>

--- a/src/app/dashboard/_components/smart-notes/hooks/useSmartNoteEditor.ts
+++ b/src/app/dashboard/_components/smart-notes/hooks/useSmartNoteEditor.ts
@@ -12,6 +12,7 @@ interface UseSmartNoteEditorProps {
   onSave: (content: string, title?: string) => void;
   onToggleShortcuts: () => void;
   onRequestAIInsights: (noteId: string, note: Note) => Promise<void>;
+  isEditingTitle?: boolean;
 }
 
 export function useSmartNoteEditor({
@@ -19,7 +20,8 @@ export function useSmartNoteEditor({
   onUpdate,
   onSave,
   onToggleShortcuts,
-  onRequestAIInsights
+  onRequestAIInsights,
+  isEditingTitle = false
 }: UseSmartNoteEditorProps) {
   // Core state
   const [content, setContent] = useState(note.content || '');
@@ -60,13 +62,14 @@ export function useSmartNoteEditor({
   // Memoized condition for title generation
   const shouldGenerateTitle = useMemo(() => {
     return (
+      !isEditingTitle &&
       !titleGenerated && // Not already generated
       !isGeneratingTitle && // Not currently generating
       !titleLoading && // Hook not busy
       (!note.title || note.title === 'Untitled Note' || note.title.trim() === '') && // No meaningful title
       content.trim().length >= 20 // Sufficient content
     );
-  }, [titleGenerated, isGeneratingTitle, titleLoading, note.title, content]);
+  }, [isEditingTitle, titleGenerated, isGeneratingTitle, titleLoading, note.title, content]);
   
   // Debounced content update - separate from title generation
   const debouncedContentUpdate = useCallback((newContent: string) => {

--- a/src/app/dashboard/_components/smart-notes/index.tsx
+++ b/src/app/dashboard/_components/smart-notes/index.tsx
@@ -74,7 +74,7 @@ export default function SmartNotes() {
   const [showSidebar, setShowSidebar] = useState(true); // Make sidebar visible by default
   
   // Get notes and mutations from useSmartNotes hook
-  const { notes, isLoading, saveNote, updateNote, deleteNote, saveNoteContent } = useSmartNotes(userId);
+  const { notes, isLoading, saveNote, updateNote, deleteNote, saveNoteContent, setNotes } = useSmartNotes(userId);
   
   const { requestAIInsights } = useAIInsights(updateNote); // updateNote from useSmartNotes is passed here
   const { setIsViewingNote } = useSidebar();
@@ -98,11 +98,7 @@ export default function SmartNotes() {
     if (result.success && result.noteId) {
       setActiveNoteId(result.noteId.toString()); // Convex IDs are objects, convert to string for activeNoteId state
       setShowSidebar(false);
-    } else {
-      console.error("Failed to create note via Convex immediately");
-      // Fallback or error handling: maybe create a purely local note if immediate save fails
-      // For now, log error. The UI might not show a new note if this fails.
-    }
+    } 
   }, [userId, saveNote]);
 
 
@@ -195,11 +191,15 @@ export default function SmartNotes() {
           <NoteArea
             note={activeNote}
             onUpdate={async (noteId, updates) => {
-              // Optimistic update (manual setNotes) can be done here if desired for immediate UI feedback.
-              // However, updateNote (from useSmartNotes) will trigger Convex update, and reactivity should refresh the notes list.
-              // For simplicity, relying on Convex reactivity initially.
-              // const currentNotes = notes || [];
-              // setNotes(currentNotes.map(note => note._id.toString() === noteId.toString() ? { ...note, ...updates } as Note : note));
+              // Optimistically update the note in local state
+              setNotes(currentNotes =>
+                currentNotes.map(note =>
+                  note._id.toString() === noteId.toString()
+                    ? { ...note, ...updates }
+                    : note
+                )
+              );
+              // Then call the backend update
               return await updateNote(noteId, updates);
             }}
             onSave={handleSave}


### PR DESCRIPTION


**Fix: Prevent Smart Notes Title Field from Constantly Re-rendering and Overwriting User Input**

---

## Description

This PR fixes the issue where the title input in the Smart Notes editor was constantly being reset on every keystroke, making it impossible for users to edit the note title.

### Key Changes

- **NoteMeta.tsx**:  
  - The local `title` state is now only updated from props when the user is *not* editing (`isEditing` is false).  
  - While editing, the input is controlled by the user and not overwritten by parent prop changes.
- **NoteArea.tsx & useSmartNoteEditor.ts**:  
  - The `isEditingTitle` flag is passed through to pause any auto-title generation logic while the user is editing the title.
- **User Experience**:  
  - Users can now freely edit the note title without it being reset by backend or AI-generated updates.

### Why

Previously, every keystroke in the title field triggered a parent re-render, which reset the input value from props. This made the title uneditable.  
This change ensures the input is only controlled by the user while editing, and only syncs with props when not editing.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved note editing experience by allowing users to edit note titles directly and providing immediate feedback when editing.
- **Enhancements**
	- Optimistic UI updates now reflect note changes instantly, making the interface more responsive.
- **Bug Fixes**
	- Prevented automatic title generation while the user is editing a note title to avoid overwriting user input.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->