### PR TITLE
feat: add getUserInfo query to retrieve user details by userId

### DIFF
--- a/convex/userQueries.ts
+++ b/convex/userQueries.ts
@@ -92,4 +92,28 @@ export const getUserByStripeSubscriptionId = query({
       .first()
   }
 })
+
+export const getUserInfo = query({
+  args: { userId: v.string() },
+  handler: async (ctx, args) => {
+    const user = await ctx.db
+      .query("users")
+      .withIndex("by_userId", (q) => q.eq("userId", args.userId))
+      .first();
+    
+    if (!user) return null;
+    
+    return {
+      id: user._id,
+      email: user.email,
+      name: user.name,
+      image: user.image,
+      userId: user.userId,
+      username: user.username || '',
+      referralCode: user.referralCode || '',
+      referredBy: user.referredBy || '',
+      createdAt: new Date(user._creationTime).toISOString()
+    };
+  },
+});
   


### PR DESCRIPTION
This pull request introduces a new query function, `getUserInfo`, in the `convex/userQueries.ts` file. The function retrieves detailed user information based on a provided `userId`.

This is for the mobile app to easily get user data without including subscription info. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability to retrieve user information using a user ID, returning key profile details and account creation date. If the user is not found, the result will be empty.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->