### PR TITLE
feat: migrate smart notes to new 6-type system

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -31,6 +31,7 @@ import type * as personaQueries from "../personaQueries.js";
 import type * as personas from "../personas.js";
 import type * as priceConfig from "../priceConfig.js";
 import type * as rateLimiting from "../rateLimiting.js";
+import type * as smartNotesMutation from "../smartNotesMutation.js";
 import type * as subscriptionActions from "../subscriptionActions.js";
 import type * as subscriptionQueries from "../subscriptionQueries.js";
 import type * as usageEvents from "../usageEvents.js";
@@ -68,6 +69,7 @@ declare const fullApi: ApiFromModules<{
   personas: typeof personas;
   priceConfig: typeof priceConfig;
   rateLimiting: typeof rateLimiting;
+  smartNotesMutation: typeof smartNotesMutation;
   subscriptionActions: typeof subscriptionActions;
   subscriptionQueries: typeof subscriptionQueries;
   usageEvents: typeof usageEvents;

--- a/convex/notes.ts
+++ b/convex/notes.ts
@@ -5,23 +5,21 @@ import { error } from "console";
 
 // Type definition for note types and reference types
 const noteType = v.union(
-  v.literal("ai_insight"),
-  v.literal("conversation"),
-  v.literal("idea"),
-  v.literal("url"),
-  v.literal("date"),
-  v.literal("brainstorm"),
-  v.literal("click")
+  v.literal("idea_bank"),
+  v.literal("content_script"),
+  v.literal("collaboration_note"),
+  v.literal("analytics_insight"),
+  v.literal("reflection_journal"),
+  v.literal("task_checklist")
 );
 
 const referenceType = v.union(
-  v.literal("ai_insight"),
-  v.literal("conversation"),
-  v.literal("idea"),
-  v.literal("url"),
-  v.literal("date"),
-  v.literal("brainstorm"),
-  v.literal("click")
+  v.literal("idea_bank"),
+  v.literal("content_script"),
+  v.literal("collaboration_note"),
+  v.literal("analytics_insight"),
+  v.literal("reflection_journal"),
+  v.literal("task_checklist")
 );
 
 // CREATE NOTE MUTATION
@@ -47,7 +45,7 @@ export const createNote = mutation({
       title: typeof args.title === "string" ? args.title : "",
       content: args.content ?? "",
       platform: args.platform ?? "",
-      type: args.type ?? "idea",
+      type: args.type ?? "idea_bank",
       important: args.important ?? false,
       tags: Array.isArray(args.tags) ? args.tags : [],
       createdAt: now,
@@ -228,42 +226,84 @@ export const getAnalysisforNote = query({
 });
 
 // Type-specific queries
-export const getIdeas = query({
+export const getIdeaBank = query({
   args: { userId: v.string() },
   handler: async (ctx, args) => {
     return await ctx.db
       .query("notes")
       .filter((q) =>
         q.eq(q.field("userId"), args.userId) &&
-        q.eq(q.field("type"), "idea")
+        q.eq(q.field("type"), "idea_bank")
       )
       .order("desc")
       .collect();
   },
 });
 
-export const getAIInsights = query({
+export const getContentScripts = query({
   args: { userId: v.string() },
   handler: async (ctx, args) => {
     return await ctx.db
       .query("notes")
       .filter((q) =>
         q.eq(q.field("userId"), args.userId) &&
-        q.eq(q.field("type"), "ai_insight")
+        q.eq(q.field("type"), "content_script")
       )
       .order("desc")
       .collect();
   },
 });
 
-export const getConversations = query({
+export const getCollaborationNotes = query({
   args: { userId: v.string() },
   handler: async (ctx, args) => {
     return await ctx.db
       .query("notes")
       .filter((q) =>
         q.eq(q.field("userId"), args.userId) &&
-        q.eq(q.field("type"), "conversation")
+        q.eq(q.field("type"), "collaboration_note")
+      )
+      .order("desc")
+      .collect();
+  },
+});
+
+export const getAnalyticsInsights = query({
+  args: { userId: v.string() },
+  handler: async (ctx, args) => {
+    return await ctx.db
+      .query("notes")
+      .filter((q) =>
+        q.eq(q.field("userId"), args.userId) &&
+        q.eq(q.field("type"), "analytics_insight")
+      )
+      .order("desc")
+      .collect();
+  },
+});
+
+export const getReflectionJournal = query({
+  args: { userId: v.string() },
+  handler: async (ctx, args) => {
+    return await ctx.db
+      .query("notes")
+      .filter((q) =>
+        q.eq(q.field("userId"), args.userId) &&
+        q.eq(q.field("type"), "reflection_journal")
+      )
+      .order("desc")
+      .collect();
+  },
+});
+
+export const getTaskChecklists = query({
+  args: { userId: v.string() },
+  handler: async (ctx, args) => {
+    return await ctx.db
+      .query("notes")
+      .filter((q) =>
+        q.eq(q.field("userId"), args.userId) &&
+        q.eq(q.field("type"), "task_checklist")
       )
       .order("desc")
       .collect();

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -137,13 +137,12 @@ export default defineSchema({
     platform: v.optional(v.string()),
     references: v.optional(v.array(v.string())),
     type: v.optional(v.union(
-      v.literal("ai_insight"),
-      v.literal("conversation"),
-      v.literal("idea"),
-      v.literal("url"),
-      v.literal("date"),
-      v.literal("brainstorm"),
-      v.literal("click")
+      v.literal("idea_bank"),
+      v.literal("content_script"),
+      v.literal("collaboration_note"),
+      v.literal("analytics_insight"),
+      v.literal("reflection_journal"),
+      v.literal("task_checklist")
     )),
     tags: v.array(v.string()),
     analysis: v.optional(v.string()),
@@ -433,8 +432,6 @@ export default defineSchema({
         })),
       }))),
     })),
-    analytics: v.optional(v.any()),
-    public_stats: v.optional(v.any()),
     createdAt: v.optional(v.float64()),
     updatedAt: v.optional(v.float64()),
   })

--- a/convex/smartNotesMutation.ts
+++ b/convex/smartNotesMutation.ts
@@ -1,0 +1,94 @@
+import { internalMutation } from "./_generated/server";
+
+// Valid new note types
+type NewNoteType = "idea_bank" | "content_script" | "collaboration_note" | "analytics_insight" | "reflection_journal" | "task_checklist";
+
+// Migration mapping from old note types to new note types
+const TYPE_MIGRATION_MAP: Record<string, NewNoteType> = {
+  // Old type -> New type
+  "idea": "idea_bank",
+  "ai_insight": "analytics_insight", 
+  "conversation": "reflection_journal",
+  "brainstorm": "idea_bank",
+  "url": "idea_bank",
+  "date": "task_checklist",
+  "click": "idea_bank"
+};
+
+export const migrateNoteTypes = internalMutation({
+  handler: async (ctx) => {
+    console.log("🚀 Starting note type migration...");
+    
+    // Get all notes that need migration
+    const allNotes = await ctx.db.query("notes").collect();
+    let migrationCount = 0;
+    
+    for (const note of allNotes) {
+      const currentType = note.type;
+      
+      // Check if this note needs migration
+      if (currentType && TYPE_MIGRATION_MAP[currentType]) {
+        const newType = TYPE_MIGRATION_MAP[currentType];
+        
+        console.log(`Migrating note ${note._id}: ${currentType} -> ${newType}`);
+        
+        await ctx.db.patch(note._id, {
+          type: newType as any,
+          updatedAt: Date.now()
+        });
+        
+        migrationCount++;
+      }
+    }
+    
+    console.log(`✅ Migration complete! Updated ${migrationCount} notes.`);
+    return { 
+      success: true, 
+      migratedNotes: migrationCount,
+      totalNotes: allNotes.length 
+    };
+  },
+});
+
+export const rollbackNoteTypes = internalMutation({
+  handler: async (ctx) => {
+    console.log("🔄 Rolling back note type migration...");
+    
+    // Reverse mapping for rollback
+    const ROLLBACK_MAP: Record<NewNoteType, string> = {
+      "idea_bank": "idea",
+      "analytics_insight": "ai_insight",
+      "reflection_journal": "conversation", 
+      "task_checklist": "date",
+      "content_script": "idea",
+      "collaboration_note": "idea"
+    };
+    
+    const allNotes = await ctx.db.query("notes").collect();
+    let rollbackCount = 0;
+    
+    for (const note of allNotes) {
+      const currentType = note.type;
+      
+      if (currentType && ROLLBACK_MAP[currentType as NewNoteType]) {
+        const oldType = ROLLBACK_MAP[currentType as NewNoteType];
+        
+        console.log(`Rolling back note ${note._id}: ${currentType} -> ${oldType}`);
+        
+        await ctx.db.patch(note._id, {
+          type: oldType as any, // Cast to any since we're going back to old schema temporarily
+          updatedAt: Date.now()
+        });
+        
+        rollbackCount++;
+      }
+    }
+    
+    console.log(`✅ Rollback complete! Updated ${rollbackCount} notes.`);
+    return { 
+      success: true, 
+      rolledBackNotes: rollbackCount,
+      totalNotes: allNotes.length 
+    };
+  },
+}); 

--- a/src/app/dashboard/notes/types/index.ts
+++ b/src/app/dashboard/notes/types/index.ts
@@ -1,6 +1,6 @@
 import { Id } from "@/convex/_generated/dataModel";
 
-export type NoteType = 'ai_insight' | 'conversation' | 'idea' | 'url' | 'date' | 'brainstorm' | 'click';
+export type NoteType = 'idea_bank' | 'content_script' | 'collaboration_note' | 'analytics_insight' | 'reflection_journal' | 'task_checklist';
 
 
 export interface Note {


### PR DESCRIPTION
- Replace 7 legacy note types with 6 focused categories: • idea_bank: Early-stage ideas, hooks, prompts • content_script: Structured posts/video scripts • collaboration_note: Brand deals, partnerships, collabs • analytics_insight: Performance analysis & learnings • reflection_journal: Personal thoughts & creative process • task_checklist: Shot lists, tasks, reminders

- Update Convex schema and mutations to use new types
- Change default note type from idea to idea_bank
- Replace type-specific queries (getIdeas → getIdeaBank, etc.)
- Update frontend TypeScript definitions
- Migrate existing notes from old to new type system

BREAKING CHANGE: Note type values have changed. Existing notes automatically migrated during deployment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced new note types: idea bank, content script, collaboration note, analytics insight, reflection journal, and task checklist.
  - Added new queries to retrieve notes by these new types.

- **Bug Fixes**
  - Updated default note type for new notes to "idea bank".

- **Chores**
  - Removed deprecated note types and associated queries.
  - Cleaned up schema by removing unused fields from the YouTube videos data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->