### PR TITLE
feat: add CreateNoteButton component 

### DIFF
--- a/src/app/dashboard/_components/content-hub/ContentHubScreen.tsx
+++ b/src/app/dashboard/_components/content-hub/ContentHubScreen.tsx
@@ -52,6 +52,7 @@ export function ContentHubScreen() {
   )
   const [selectedContent, setSelectedContent] = useState<AnyContentItem | null>(null)
   const [currentQuote, setCurrentQuote] = useState<string>('')
+  const [expandedInsight, setExpandedInsight] = useState<string | null>(null);
   
   const { firebaseUser, authLoading } = useAuth()
   const userId = firebaseUser?.uid
@@ -274,12 +275,17 @@ export function ContentHubScreen() {
     if (allInsights.length > 0) {
       return (
         <div className="grid gap-6">
-          {allInsights.map((insight, idx) => (
-            <InsightCard
-              key={`${insight.platform}-${idx}`}
-              {...insight}
-            />
-          ))}
+          {allInsights.map((insight, idx) => {
+            const insightId = `${insight.platform}-${idx}`;
+            return (
+              <InsightCard
+                key={insightId}
+                {...insight}
+                expanded={expandedInsight === insightId}
+                onExpand={() => setExpandedInsight(expandedInsight === insightId ? null : insightId)}
+              />
+            );
+          })}
         </div>
       )
     }

--- a/src/app/dashboard/ai-insights/_components/InsightCard.tsx
+++ b/src/app/dashboard/ai-insights/_components/InsightCard.tsx
@@ -4,6 +4,7 @@ import { YouTubeBrandIcon } from '../../../../lib/YoutubeBrandIcon';
 import { Card } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { useActionStepDiscussion } from './hooks/useActionStepDiscussion';
+import { CreateNoteButton } from '@/components/ui/CreateNoteButton';
 
 export interface InsightCardProps {
   platform: 'youtube' | 'instagram' | 'gmail';
@@ -142,6 +143,30 @@ ${relatedItems && relatedItems.length > 0 ? `### Related Items\n${relatedItems.m
     
     const encodedContext = encodeURIComponent(JSON.stringify(fullInsightContext));
     window.location.href = `/dashboard/chat?contentContext=${encodedContext}`;
+  };
+
+  const formatInsightForNote = () => {
+    const cleanImpact = impact.replace(/^Impact:\s*/i, '');
+    return `
+# ${title}
+
+**Platform:** ${validatedPlatform.toUpperCase()}
+**Impact:** ${cleanImpact}
+
+### Why Now?
+${whyNow.map(reason => `• ${reason}`).join('\n')}
+
+### Action Steps
+${actionSteps.map((step, idx) => `${idx + 1}. ${step}`).join('\n')}
+
+### Expected Outcome
+${expectedOutcome}
+
+### Source Details
+${sourceDetails.join('\n')}
+
+${relatedItems && relatedItems.length > 0 ? `### Related Items\n${relatedItems.map(item => `• ${item.label}: ${item.value}`).join('\n')}` : ''}
+    `.trim();
   };
 
   const getPlatformShadow = () => {
@@ -310,6 +335,18 @@ ${relatedItems && relatedItems.length > 0 ? `### Related Items\n${relatedItems.m
               <MessageSquare className="w-4 h-4 mr-2" />
               Discuss With Content
             </Button>
+
+            <CreateNoteButton
+              content={formatInsightForNote()}
+              onNoteCreate={() => {
+                // Optionally add some feedback to the user, like a toast.
+                // For now, it just creates the note and navigates.
+              }}
+              className="flex-1"
+              onClick={(e: React.MouseEvent) => e.stopPropagation()}
+            >
+              Create Note
+            </CreateNoteButton>
             
             {/* Legacy discuss button if provided */}
             {onDiscuss && (

--- a/src/app/dashboard/chat/ChatContainer.tsx
+++ b/src/app/dashboard/chat/ChatContainer.tsx
@@ -418,14 +418,6 @@ const ChatContainer: React.FC<ChatScreenProps> = ({ chatId, contentContext, askQ
     });
   }, []);
 
-  const handleCreateNoteFromNotepad = (content: string) => {
-    const newNoteId = createLocalNote(content);
-    if (newNoteId) {
-      setActiveNoteId(newNoteId);
-      router.push('/dashboard/notes');
-    }
-  };
-
   // Always render the static UI shell, even when authentication is in progress
   // User-dependent content will be conditionally rendered
 
@@ -574,7 +566,6 @@ const ChatContainer: React.FC<ChatScreenProps> = ({ chatId, contentContext, askQ
         isOpen={notepadOpen}
         onClose={toggleNotepad}
         onSendToChat={handleNotepadSendToChat}
-        onCreateNote={handleCreateNoteFromNotepad}
         quotedContent={quotedForNotepad}
         onClearQuoted={handleClearQuoted}
         width={notepadWidth}

--- a/src/app/dashboard/chat/components/MarkdownNotepad.tsx
+++ b/src/app/dashboard/chat/components/MarkdownNotepad.tsx
@@ -1,13 +1,13 @@
 'use client'
 
 import { useState, useRef, useEffect } from 'react'
-import { X, FileText, Send, Copy, FilePlus } from 'lucide-react'
+import { X, Send, Copy } from 'lucide-react'
+import { CreateNoteButton } from '@/components/ui/CreateNoteButton'
 
 interface MarkdownNotepadProps {
   isOpen: boolean
   onClose: () => void
   onSendToChat?: (content: string) => void
-  onCreateNote?: (content: string) => void
   quotedContent?: string
   onClearQuoted?: () => void
   width: number
@@ -15,7 +15,7 @@ interface MarkdownNotepadProps {
   style: React.CSSProperties
 }
 
-export function MarkdownNotepad({ isOpen, onClose, onSendToChat, onCreateNote, quotedContent, onClearQuoted, width, onWidthChange, style }: MarkdownNotepadProps) {
+export function MarkdownNotepad({ isOpen, onClose, onSendToChat, quotedContent, onClearQuoted, width, onWidthChange, style }: MarkdownNotepadProps) {
   const [content, setContent] = useState('')
   const [isResizing, setIsResizing] = useState(false)
   const textareaRef = useRef<HTMLTextAreaElement>(null)
@@ -101,13 +101,6 @@ export function MarkdownNotepad({ isOpen, onClose, onSendToChat, onCreateNote, q
     }
   }
 
-  const handleCreateNote = () => {
-    if (content.trim() && onCreateNote) {
-      onCreateNote(content.trim());
-      onClose();
-    }
-  };
-
   const handleCopy = async () => {
     if (content.trim()) {
       try {
@@ -147,17 +140,13 @@ export function MarkdownNotepad({ isOpen, onClose, onSendToChat, onCreateNote, q
         
         <div className="flex items-center gap-1">
           {/* Create Note Button */}
-          {onCreateNote && (
-            <button
-              onClick={handleCreateNote}
-              disabled={!content.trim()}
-              className="flex items-center gap-1 px-2 py-1 text-xs bg-purple-500 hover:bg-purple-600 text-white rounded transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-              title="Create a new smart note"
-            >
-              <FilePlus className="w-3 h-3" />
-              Create Note
-            </button>
-          )}
+          <CreateNoteButton
+            content={content}
+            onNoteCreate={onClose}
+            title="Create a new smart note"
+          >
+            Create Note
+          </CreateNoteButton>
 
           {/* Copy Button */}
           <button

--- a/src/app/hooks/useCreateNote.ts
+++ b/src/app/hooks/useCreateNote.ts
@@ -1,0 +1,24 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useNotes } from '@/app/context/notes-context';
+
+export const useCreateNote = () => {
+  const router = useRouter();
+  const { createLocalNote, setActiveNoteId } = useNotes();
+
+  const createNote = (content: string, callback?: () => void) => {
+    if (!content.trim()) return;
+    
+    const newNoteId = createLocalNote(content);
+    if (newNoteId) {
+      setActiveNoteId(newNoteId);
+      router.push('/dashboard/notes');
+      if (callback) {
+        callback();
+      }
+    }
+  };
+
+  return { createNote };
+}; 

--- a/src/components/ui/CreateNoteButton.tsx
+++ b/src/components/ui/CreateNoteButton.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import { useCreateNote } from '@/app/hooks/useCreateNote';
+import { Button } from './button';
+import React from 'react';
+import { FilePlus } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+interface CreateNoteButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  content: string;
+  onNoteCreate?: () => void;
+  children?: React.ReactNode;
+}
+
+export const CreateNoteButton = React.forwardRef<HTMLButtonElement, CreateNoteButtonProps>(
+  ({ content, children, onClick, onNoteCreate, className, ...props }, ref) => {
+    const { createNote } = useCreateNote();
+
+    const handleCreateNote = (e: React.MouseEvent<HTMLButtonElement>) => {
+      if (onClick) {
+        onClick(e);
+      }
+      createNote(content, onNoteCreate);
+    };
+
+    return (
+      <Button
+        ref={ref}
+        onClick={handleCreateNote}
+        disabled={!content.trim() || props.disabled}
+        variant="ghost"
+        className={cn("text-xs bg-gray-100 dark:bg-gray-800", className)}
+        {...props}
+      >
+        <FilePlus />
+        {children}
+      </Button>
+    );
+  }
+);
+
+CreateNoteButton.displayName = 'CreateNoteButton';


### PR DESCRIPTION
This pull request introduces a new `CreateNoteButton` component and refactors the note creation logic across multiple parts of the application to improve reusability and maintainability. It also enhances the `ContentHubScreen` and `InsightCard` components with new functionality for managing expanded insights and formatting insights for notes.

### New Note Creation Component and Logic Refactor:
* Added a reusable `CreateNoteButton` component that integrates with the `useCreateNote` hook to handle note creation, including navigation and optional callbacks. (`src/components/ui/CreateNoteButton.tsx`, [src/components/ui/CreateNoteButton.tsxR1-R42](diffhunk://#diff-b1e808c7beee81cb5411f7038e83dfc84858608c4b29440e8a2fc889077786c6R1-R42))
* Introduced a `useCreateNote` hook to centralize note creation logic, replacing inline implementations across the app. (`src/app/hooks/useCreateNote.ts`, [src/app/hooks/useCreateNote.tsR1-R24](diffhunk://#diff-b8be18aae4e3072eb851ee07f1ebc4d3a24fbc15c7278c0acb763629f67d27c4R1-R24))
* Removed redundant note creation logic from `MarkdownNotepad` and replaced it with the new `CreateNoteButton`. (`src/app/dashboard/chat/components/MarkdownNotepad.tsx`, [[1]](diffhunk://#diff-e37024b69763a8ac087d889da7b3be1e19f001267654b5900b9faf368a1a5803L4-R18) [[2]](diffhunk://#diff-e37024b69763a8ac087d889da7b3be1e19f001267654b5900b9faf368a1a5803L104-L110) [[3]](diffhunk://#diff-e37024b69763a8ac087d889da7b3be1e19f001267654b5900b9faf368a1a5803L150-R149)
* Removed the `handleCreateNoteFromNotepad` function and its usage in `ChatContainer`, as it is now handled by the `CreateNoteButton`. (`src/app/dashboard/chat/ChatContainer.tsx`, [[1]](diffhunk://#diff-eda28b05cc40874b622befdf8be6cec623f40b65593a2feb306c117819fd1754L421-L428) [[2]](diffhunk://#diff-eda28b05cc40874b622befdf8be6cec623f40b65593a2feb306c117819fd1754L577)

### Enhancements to Content and Insight Management:
* Added a new state, `expandedInsight`, to `ContentHubScreen` to track which insight is expanded, and updated the `InsightCard` rendering logic to support this functionality. (`src/app/dashboard/_components/content-hub/ContentHubScreen.tsx`, [[1]](diffhunk://#diff-f68e1d23dd2d8e677148e162c3516be6b00b1039115fe05fca8976159e366334R55) [[2]](diffhunk://#diff-f68e1d23dd2d8e677148e162c3516be6b00b1039115fe05fca8976159e366334L277-R288)
* Implemented a `formatInsightForNote` function in `InsightCard` to generate a structured note from insight data, improving note creation workflows. (`src/app/dashboard/ai-insights/_components/InsightCard.tsx`, [src/app/dashboard/ai-insights/_components/InsightCard.tsxR148-R171](diffhunk://#diff-792609a96b9dfcf1cd91af3d45c2e0992138b0666bbcb97207d0d527955fe697R148-R171))
* Integrated the `CreateNoteButton` into `InsightCard`, allowing users to create notes directly from insights. (`src/app/dashboard/ai-insights/_components/InsightCard.tsx`, [src/app/dashboard/ai-insights/_components/InsightCard.tsxR339-R350](diffhunk://#diff-792609a96b9dfcf1cd91af3d45c2e0992138b0666bbcb97207d0d527955fe697R339-R350))

These changes collectively improve the user experience for creating and managing notes while streamlining the codebase for better maintainability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability to expand and collapse individual insight cards for a more detailed view.
  - Introduced a "Create Note" button to insight cards, allowing users to quickly generate notes from insights.
  - Added a dedicated "Create Note" button to the markdown notepad for streamlined note creation.

- **Refactor**
  - Improved the markdown notepad by replacing the inline note creation logic with a reusable button component.
  - Centralized note creation logic via a new internal hook for consistent behavior across the app.

- **Chores**
  - Updated button styling and UI consistency for note creation actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->