### PR TITLE
fix: adjust layout and styling in PersonaTimeline component

### DIFF
--- a/src/app/settings/tabs/account/PersonaTimeline.tsx
+++ b/src/app/settings/tabs/account/PersonaTimeline.tsx
@@ -34,11 +34,11 @@ export const PersonaTimeline: React.FC<PersonaTimelineProps> = ({ history, onRes
     <div className="p-4">
       <div className="flex flex-col md:flex-row md:items-start md:space-x-8">
         {history.map((persona, index) => (
-          <div key={persona._id} className="group relative flex pb-8 last:pb-0 md:flex-col md:flex-1 md:pb-0">
+          <div key={persona._id} className="group relative flex pb-8 last:pb-0 md:flex-col md:flex-1 md:pb-0 md:items-center">
             {/* Connectors: Vertical for mobile, horizontal for web */}
             <div className="absolute top-3 left-3 -ml-px h-full w-px bg-gray-200 group-last:hidden md:hidden" />
             {index < history.length - 1 && (
-              <div className="hidden md:block absolute top-3 left-1/2 w-full h-px bg-gray-200" />
+              <div className="hidden md:block absolute top-3 left-1/2 w-full h-px bg-gray-200 -translate-x-1/2" />
             )}
             
             {/* Dot */}


### PR DESCRIPTION
This pull request includes a small improvement to the layout of the `PersonaTimeline` component in `src/app/settings/tabs/account/PersonaTimeline.tsx`. The changes enhance the alignment and positioning of elements for better visual consistency.

* Improved alignment of timeline items by adding the `md:items-center` class to the container div.
* Adjusted the horizontal connector's positioning by adding the `-translate-x-1/2` class for proper centering.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved vertical and horizontal alignment of timeline items and connector lines for medium and larger screens in the account settings timeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->