### PR TITLE
Adding connect to platform to ContentHub

### DIFF
--- a/src/app/dashboard/_components/content-hub/ContentHubInsights.tsx
+++ b/src/app/dashboard/_components/content-hub/ContentHubInsights.tsx
@@ -89,7 +89,7 @@ export function ContentHubInsights({ userId }: ContentHubInsightsProps) {
             </p>
             <div className="flex justify-center gap-4 text-xs text-gray-500">
               <div className={`flex items-center gap-1 ${connectedPlatforms.includes('youtube') ? 'text-gray-900 dark:text-gray-100' : ''}`}>
-                <YouTubeBrandIcon href="#" className="w-4 h-4" />
+                <YouTubeBrandIcon href="https://youtube.com/" className="w-4 h-4" />
                 YouTube {connectedPlatforms.includes('youtube') ? '✓' : ''}
               </div>
               <div className={`flex items-center gap-1 ${connectedPlatforms.includes('instagram') ? 'text-gray-900 dark:text-gray-100' : ''}`}>
@@ -280,7 +280,7 @@ export function ContentHubInsights({ userId }: ContentHubInsightsProps) {
               {/* YouTube Section */}
               <PlatformInsightCard
                 platform="YouTube"
-                icon={<YouTubeBrandIcon href="#" className="w-4 h-4" />}
+                icon={<YouTubeBrandIcon href="https://youtube.com/" className="w-4 h-4" />}
                 hook={insight.youtube_hook}
                 format={insight.youtube_format}
                 cta={insight.youtube_cta}

--- a/src/app/dashboard/_components/content-hub/ContentHubScreen.tsx
+++ b/src/app/dashboard/_components/content-hub/ContentHubScreen.tsx
@@ -2,7 +2,7 @@
 
 import React, { useState, useMemo, useCallback, useEffect } from 'react'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
-import { Instagram, Mail, BarChart3, Brain, Settings } from 'lucide-react'
+import { Instagram, Mail, BarChart3, Brain, Settings, Sparkles } from 'lucide-react'
 import { useAuth } from '@/app/context/auth-context'
 import { RefreshState } from '@/components/ui/refresh-state'
 import { Skeleton } from '@/components/ui/skeleton'

--- a/src/app/dashboard/_components/content-hub/ContentHubScreen.tsx
+++ b/src/app/dashboard/_components/content-hub/ContentHubScreen.tsx
@@ -414,7 +414,7 @@ export function ContentHubScreen() {
                   All Platforms
                 </TabsTrigger>
                 <TabsTrigger value="youtube" className="flex items-center gap-2">
-                  <YouTubeBrandIcon href="#" className="w-4 h-4" />
+                  <YouTubeBrandIcon href="https://youtube.com/" className="w-4 h-4" />
                   YouTube
                 </TabsTrigger>
                 <TabsTrigger value="instagram" className="flex items-center gap-2">

--- a/src/app/dashboard/_components/content-hub/ContentHubScreen.tsx
+++ b/src/app/dashboard/_components/content-hub/ContentHubScreen.tsx
@@ -2,11 +2,12 @@
 
 import React, { useState, useMemo, useCallback, useEffect } from 'react'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
-import { Instagram, Mail, BarChart3, Brain } from 'lucide-react'
+import { Instagram, Mail, BarChart3, Brain, Settings } from 'lucide-react'
 import { useAuth } from '@/app/context/auth-context'
 import { RefreshState } from '@/components/ui/refresh-state'
 import { Skeleton } from '@/components/ui/skeleton'
 import { Card } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
 import { YouTubeBrandIcon } from '@/lib/YoutubeBrandIcon'
 
 // Analytics components and hooks
@@ -189,7 +190,45 @@ export function ContentHubScreen() {
     }
   }
 
+  // Check if any platforms are connected for "all platforms" view
+  const hasAnyPlatformConnected = youtubeAnalytics.isConnected || instagramAnalytics.isConnected || gmailAnalytics.isConnected;
+
   const renderAllPlatformsAnalytics = () => {
+    // If no platforms are connected, show connection prompt
+    if (!hasAnyPlatformConnected) {
+      return (
+        <div className="flex items-center justify-center min-h-[400px] px-4">
+          <Card className="p-6 sm:p-8 max-w-md w-full bg-gradient-to-br from-white/80 to-white/60 backdrop-blur-sm border-0 shadow-lg rounded-2xl text-center">
+            <div className="flex justify-center mb-4 sm:mb-6">
+              <div className="w-12 h-12 sm:w-16 sm:h-16 rounded-full bg-gradient-to-r from-blue-500 to-purple-600 flex items-center justify-center">
+                <BarChart3 className="w-6 h-6 sm:w-8 sm:h-8 text-white" />
+              </div>
+            </div>
+            
+            <h3 className="text-lg sm:text-xl font-semibold text-gray-900 mb-2 sm:mb-3">
+              Connect Your Platforms
+            </h3>
+            
+            <p className="text-gray-600 mb-4 sm:mb-6 text-sm leading-relaxed">
+              Connect your YouTube, Instagram, and Gmail accounts to view detailed analytics, track content performance, and get insights on your content strategy.
+            </p>
+            
+            <Button 
+              onClick={() => router.push('/settings?tab=integrations')}
+              className="w-full py-3 px-4 sm:px-6 bg-gradient-to-r from-blue-500 to-purple-600 hover:from-blue-600 hover:to-purple-700 text-white font-medium rounded-lg transition-all duration-200 flex items-center justify-center gap-2 text-sm sm:text-base"
+            >
+              <Settings className="w-4 h-4" />
+              Go to Integrations
+            </Button>
+            
+            <div className="mt-3 sm:mt-4 text-xs text-gray-500">
+              You can connect platforms in Settings → Integrations
+            </div>
+          </Card>
+        </div>
+      )
+    }
+
     if (isAnalyticsLoading && allDisplayItems.length === 0) {
       return (
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8 mt-8">
@@ -233,30 +272,61 @@ export function ContentHubScreen() {
 
     return (
       <div className="flex items-center justify-center min-h-[400px] px-4">
-        <Card className="p-6 sm:p-8 max-w-md w-full bg-card shadow-lg rounded-2xl text-center">
+        <Card className="p-6 sm:p-8 max-w-md w-full bg-gradient-to-br from-white/80 to-white/60 backdrop-blur-sm border-0 shadow-lg rounded-2xl text-center">
           <div className="flex justify-center mb-4 sm:mb-6">
             <div className="w-12 h-12 sm:w-16 sm:h-16 rounded-full bg-gradient-to-r from-blue-500 to-purple-600 flex items-center justify-center">
               <BarChart3 className="w-6 h-6 sm:w-8 sm:h-8 text-white" />
             </div>
           </div>
           
-          <h3 className="text-lg sm:text-xl font-semibold text-foreground mb-2 sm:mb-3">
+          <h3 className="text-lg sm:text-xl font-semibold text-gray-900 mb-2 sm:mb-3">
             No Content Found
           </h3>
           
-          <p className="text-muted-foreground mb-4 sm:mb-6 text-sm leading-relaxed">
-            Connect your social accounts and email to start seeing content analytics here.
+          <p className="text-gray-600 mb-4 sm:mb-6 text-sm leading-relaxed">
+            We couldn't find any content in your connected platforms. Create new content to see your analytics here.
           </p>
-          
-          <div className="mt-3 sm:mt-4 text-xs text-muted-foreground">
-            Connect YouTube, Instagram, and Gmail in Settings
-          </div>
         </Card>
       </div>
     )
   }
 
   const renderAllPlatformsInsights = () => {
+    // If no platforms are connected, show connection prompt
+    if (!hasAnyPlatformConnected) {
+      return (
+        <div className="flex items-center justify-center min-h-[400px] px-4">
+          <Card className="p-6 sm:p-8 max-w-md w-full bg-gradient-to-br from-white/80 to-white/60 backdrop-blur-sm border-0 shadow-lg rounded-2xl text-center">
+            <div className="flex justify-center mb-4 sm:mb-6">
+              <div className="w-12 h-12 sm:w-16 sm:h-16 rounded-full bg-gradient-to-r from-purple-500 to-pink-600 flex items-center justify-center">
+                <Brain className="w-6 h-6 sm:w-8 sm:h-8 text-white" />
+              </div>
+            </div>
+            
+            <h3 className="text-lg sm:text-xl font-semibold text-gray-900 mb-2 sm:mb-3">
+              Connect Your Platforms
+            </h3>
+            
+            <p className="text-gray-600 mb-4 sm:mb-6 text-sm leading-relaxed">
+              Connect your YouTube, Instagram, and Gmail accounts to receive AI-powered insights, strategic recommendations, and content performance analysis.
+            </p>
+            
+            <Button 
+              onClick={() => router.push('/settings?tab=integrations')}
+              className="w-full py-3 px-4 sm:px-6 bg-gradient-to-r from-purple-500 to-pink-600 hover:from-purple-600 hover:to-pink-700 text-white font-medium rounded-lg transition-all duration-200 flex items-center justify-center gap-2 text-sm sm:text-base"
+            >
+              <Settings className="w-4 h-4" />
+              Go to Integrations
+            </Button>
+            
+            <div className="mt-3 sm:mt-4 text-xs text-gray-500">
+              You can connect platforms in Settings → Integrations
+            </div>
+          </Card>
+        </div>
+      )
+    }
+
     if (isInsightsLoading && allInsights.length === 0) {
       return (
         <div className="grid gap-6">
@@ -293,24 +363,20 @@ export function ContentHubScreen() {
 
     return (
       <div className="flex items-center justify-center min-h-[400px] px-4">
-        <Card className="p-6 sm:p-8 max-w-md w-full bg-card shadow-lg rounded-2xl text-center">
+        <Card className="p-6 sm:p-8 max-w-md w-full bg-gradient-to-br from-white/80 to-white/60 backdrop-blur-sm border-0 shadow-lg rounded-2xl text-center">
           <div className="flex justify-center mb-4 sm:mb-6">
             <div className="w-12 h-12 sm:w-16 sm:h-16 rounded-full bg-gradient-to-r from-purple-500 to-pink-600 flex items-center justify-center">
               <Brain className="w-6 h-6 sm:w-8 sm:h-8 text-white" />
             </div>
           </div>
           
-          <h3 className="text-lg sm:text-xl font-semibold text-foreground mb-2 sm:mb-3">
+          <h3 className="text-lg sm:text-xl font-semibold text-gray-900 mb-2 sm:mb-3">
             No Insights Available
           </h3>
           
-          <p className="text-muted-foreground mb-4 sm:mb-6 text-sm leading-relaxed">
-            Connect your accounts and create content to start receiving AI-powered insights and recommendations.
+          <p className="text-gray-600 mb-4 sm:mb-6 text-sm leading-relaxed">
+            We couldn't find any insights from your connected platforms. Create new content to receive AI-powered insights and recommendations.
           </p>
-          
-          <div className="mt-3 sm:mt-4 text-xs text-muted-foreground">
-            AI insights are generated from your connected platforms
-          </div>
         </Card>
       </div>
     )

--- a/src/app/dashboard/_components/content-hub/PlatformConnectionPrompt.tsx
+++ b/src/app/dashboard/_components/content-hub/PlatformConnectionPrompt.tsx
@@ -1,0 +1,59 @@
+'use client'
+
+import React from 'react'
+import { useRouter } from 'next/navigation'
+import { Card } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { Settings } from 'lucide-react'
+
+interface PlatformConnectionPromptProps {
+  platformName: string
+  platformIcon: React.ReactNode
+  description: string
+  buttonColor: string
+  buttonHoverColor: string
+}
+
+export function PlatformConnectionPrompt({
+  platformName,
+  platformIcon,
+  description,
+  buttonColor,
+  buttonHoverColor,
+}: PlatformConnectionPromptProps) {
+  const router = useRouter()
+
+  return (
+    <div className="flex items-center justify-center min-h-[400px] px-4">
+      <Card className="p-6 sm:p-8 max-w-md w-full min-h-[320px] bg-gradient-to-br from-white/80 to-white/60 backdrop-blur-sm border-0 shadow-lg rounded-2xl text-center flex flex-col justify-between">
+        <div className="flex-1 flex flex-col justify-center">
+          <div className="flex justify-center mb-4 sm:mb-6">
+            {platformIcon}
+          </div>
+          
+          <h3 className="text-lg sm:text-xl font-semibold text-gray-900 mb-2 sm:mb-3">
+            Connect Your {platformName} Account
+          </h3>
+          
+          <p className="text-gray-600 mb-4 sm:mb-6 text-sm leading-relaxed">
+            {description}
+          </p>
+        </div>
+        
+        <div className="flex-shrink-0">
+          <Button 
+            onClick={() => router.push('/settings?tab=integrations')}
+            className={`w-full py-3 px-4 sm:px-6 ${buttonColor} ${buttonHoverColor} text-white font-medium rounded-lg transition-all duration-200 flex items-center justify-center gap-2 text-sm sm:text-base`}
+          >
+            <Settings className="w-4 h-4" />
+            Go to Integrations
+          </Button>
+          
+          <div className="mt-3 sm:mt-4 text-xs text-gray-500">
+            You can connect {platformName} in Settings → Integrations
+          </div>
+        </div>
+      </Card>
+    </div>
+  )
+} 

--- a/src/app/dashboard/ai-insights/_components/platforms/GmailPlatform.tsx
+++ b/src/app/dashboard/ai-insights/_components/platforms/GmailPlatform.tsx
@@ -7,6 +7,7 @@ import { useGmailInsights } from '../hooks/useGmailInsights'
 import { RefreshState } from '@/components/ui/refresh-state'
 import { Skeleton } from '@/components/ui/skeleton'
 import { AnalysisDepthPicker } from '../AnalysisDepthPicker'
+import { PlatformConnectionPrompt } from '../../../_components/content-hub/PlatformConnectionPrompt'
 
 interface GmailPlatformProps {
   userId?: string
@@ -37,22 +38,17 @@ export function GmailPlatform({ userId, currentQuote, loading }: GmailPlatformPr
   // Handle Gmail not connected state
   if (!isConnected) {
     return (
-      <div className="text-center py-12 px-4">
-        <Mail className="w-12 h-12 text-gray-300 mx-auto mb-4" />
-        <h3 className="text-lg font-medium text-gray-900 dark:text-white mb-2">
-          Gmail Not Connected
-        </h3>
-        <p className="text-gray-500 dark:text-gray-400 max-w-md mx-auto mb-4">
-          Connect your Gmail account to get strategic insights about brand partnerships, media opportunities, and business inquiries in your inbox.
-        </p>
-        <button 
-          onClick={() => window.location.href = '/settings?tab=integrations'}
-          className="inline-flex items-center gap-2 px-4 py-2 bg-heycontent-yellow hover:bg-heycontent-yellow/90 text-black rounded-lg font-medium transition-colors"
-        >
-          <Mail className="w-4 h-4" />
-          Connect Gmail
-        </button>
-      </div>
+      <PlatformConnectionPrompt
+        platformName="Gmail"
+        platformIcon={
+          <div className="w-12 h-12 sm:w-16 sm:h-16 rounded-full bg-red-500 flex items-center justify-center">
+            <Mail className="w-6 h-6 sm:w-8 sm:h-8 text-white" />
+          </div>
+        }
+        description="Connect your Gmail account to view detailed analytics, track content performance, and get insights on your content strategy."
+        buttonColor="bg-red-500"
+        buttonHoverColor="hover:bg-red-600"
+      />
     )
   }
 

--- a/src/app/dashboard/ai-insights/_components/platforms/InstagramPlatform.tsx
+++ b/src/app/dashboard/ai-insights/_components/platforms/InstagramPlatform.tsx
@@ -7,6 +7,7 @@ import { useInstagramInsights } from '../hooks/useInstagramInsights'
 import { RefreshState } from '@/components/ui/refresh-state'
 import { Skeleton } from '@/components/ui/skeleton'
 import { AnalysisDepthPicker } from '../AnalysisDepthPicker'
+import { PlatformConnectionPrompt } from '../../../_components/content-hub/PlatformConnectionPrompt'
 
 interface InstagramPlatformProps {
   userId?: string
@@ -36,23 +37,17 @@ export function InstagramPlatform({ userId, currentQuote, loading }: InstagramPl
   // Handle Instagram not connected state
   if (!isConnected) {
     return (
-      <div className="text-center py-12 px-4">
-        <Instagram className="w-12 h-12 text-gray-300 mx-auto mb-4" />
-        <h3 className="text-lg font-medium text-gray-900 dark:text-white mb-2">
-          Instagram Not Connected
-        </h3>
-        <p className="text-gray-500 dark:text-gray-400 max-w-md mx-auto mb-4">
-          Connect your Instagram account to get strategic insights about post performance, 
-          audience engagement, and growth opportunities.
-        </p>
-        <button 
-          onClick={() => window.location.href = '/settings?tab=integrations'}
-          className="inline-flex items-center gap-2 px-4 py-2 bg-gradient-to-r from-purple-500 to-pink-500 hover:from-purple-600 hover:to-pink-600 text-white rounded-lg font-medium transition-colors"
-        >
-          <Instagram className="w-4 h-4" />
-          Connect Instagram
-        </button>
-      </div>
+      <PlatformConnectionPrompt
+        platformName="Instagram"
+        platformIcon={
+          <div className="w-12 h-12 sm:w-16 sm:h-16 rounded-full bg-gradient-to-r from-purple-500 to-pink-500 flex items-center justify-center">
+            <Instagram className="w-6 h-6 sm:w-8 sm:h-8 text-white" />
+          </div>
+        }
+        description="Connect your Instagram account to view detailed analytics, track content performance, and get insights on your content strategy."
+        buttonColor="bg-gradient-to-r from-purple-500 to-pink-500"
+        buttonHoverColor="hover:from-purple-600 hover:to-pink-600"
+      />
     )
   }
 

--- a/src/app/dashboard/ai-insights/_components/platforms/YouTubePlatform.tsx
+++ b/src/app/dashboard/ai-insights/_components/platforms/YouTubePlatform.tsx
@@ -8,6 +8,7 @@ import { Skeleton } from '@/components/ui/skeleton'
 import { AnalysisDepthPicker } from '../AnalysisDepthPicker'
 import { YouTubeBrandIcon } from '../../../../../lib/YoutubeBrandIcon'
 import { Button } from '@/components/ui/button'
+import { PlatformConnectionPrompt } from '../../../_components/content-hub/PlatformConnectionPrompt'
 
 interface YouTubePlatformProps {
   userId?: string
@@ -47,23 +48,17 @@ export function YouTubePlatform({ userId, currentQuote, loading }: YouTubePlatfo
   // Handle YouTube not connected state
   if (!isConnected) {
     return (
-      <div className="space-y-6">
-        <div className="flex justify-between items-center">
-          <Skeleton className="h-10 w-32" />
-          <Skeleton className="h-10 w-32" />
-        </div>
-        <div className="grid gap-6">
-          {Array.from({ length: 3 }).map((_, index) => (
-            <div key={index} className="rounded-lg border bg-card text-card-foreground shadow-sm p-6 flex flex-col space-y-4">
-              <Skeleton className="h-5 w-3/4" />
-              <div className="space-y-2">
-                <Skeleton className="h-4 w-full" />
-                <Skeleton className="h-4 w-5/6" />
-              </div>
-            </div>
-          ))}
-        </div>
-      </div>
+      <PlatformConnectionPrompt
+        platformName="YouTube"
+        platformIcon={
+          <div className="w-12 h-12 sm:w-16 sm:h-16 flex items-center justify-center">
+            <YouTubeBrandIcon href="https://youtube.com/" className="w-full h-full" />
+          </div>
+        }
+        description="Connect your YouTube account to view detailed analytics, track video performance, and get insights on your content strategy."
+        buttonColor="bg-red-600"
+        buttonHoverColor="hover:bg-red-700"
+      />
     )
   }
 

--- a/src/app/dashboard/ai-insights/_components/platforms/YouTubePlatform.tsx
+++ b/src/app/dashboard/ai-insights/_components/platforms/YouTubePlatform.tsx
@@ -93,7 +93,7 @@ export function YouTubePlatform({ userId, currentQuote, loading }: YouTubePlatfo
             onClick={() => window.location.href = '/settings?tab=integrations'}
             className="inline-flex items-center gap-2 px-4 py-2 bg-red-600 hover:bg-red-700 text-white rounded-lg font-medium transition-colors"
           >
-            <YouTubeBrandIcon href={null} className="w-4 h-4" />
+            <YouTubeBrandIcon href="https://youtube.com/" className="w-4 h-4" />
             Connect YouTube
           </Button>
         </div>

--- a/src/app/dashboard/content-analytics/platforms/GmailPlatform.tsx
+++ b/src/app/dashboard/content-analytics/platforms/GmailPlatform.tsx
@@ -12,6 +12,7 @@ import { useGmailAnalytics } from '../hooks/useGmailAnalytics';
 import { GmailContentItem, AnyContentItem } from '../types';
 import { sortContent } from '../utils';
 import { Skeleton } from '@/components/ui/skeleton';
+import { PlatformConnectionPrompt } from '../../_components/content-hub/PlatformConnectionPrompt';
 
 interface GmailPlatformProps {
   userId: string;
@@ -90,36 +91,17 @@ export function GmailPlatform({
   // Show Gmail connect card if no Gmail account found
   if (!isConnected) {
     return (
-      <div className="flex items-center justify-center min-h-[400px] px-4">
-        <Card className="p-6 sm:p-8 max-w-md w-full bg-gradient-to-br from-white/80 to-white/60 backdrop-blur-sm border-0 shadow-lg rounded-2xl text-center">
-          <div className="flex justify-center mb-4 sm:mb-6">
-            <div className="w-12 h-12 sm:w-16 sm:h-16 rounded-full bg-red-500 flex items-center justify-center">
-              <Mail className="w-6 h-6 sm:w-8 sm:h-8 text-white" />
-            </div>
+      <PlatformConnectionPrompt
+        platformName="Gmail"
+        platformIcon={
+          <div className="w-12 h-12 sm:w-16 sm:h-16 rounded-full bg-red-500 flex items-center justify-center">
+            <Mail className="w-6 h-6 sm:w-8 sm:h-8 text-white" />
           </div>
-          
-          <h3 className="text-lg sm:text-xl font-semibold text-gray-900 mb-2 sm:mb-3">
-            Connect Your Gmail Account
-          </h3>
-          
-          <p className="text-gray-600 mb-4 sm:mb-6 text-sm leading-relaxed">
-            Connect your Gmail account to view email analytics, track business communications, 
-            and get insights on partnership opportunities.
-          </p>
-          
-          <Button 
-            onClick={() => router.push('/settings?tab=integrations')}
-            className="w-full py-3 px-4 sm:px-6 bg-red-500 hover:bg-red-600 text-white font-medium rounded-lg transition-all duration-200 flex items-center justify-center gap-2 text-sm sm:text-base"
-          >
-            <Settings className="w-4 h-4" />
-            Go to Integrations
-          </Button>
-          
-          <div className="mt-3 sm:mt-4 text-xs text-gray-500">
-            You can connect Gmail in Settings → Integrations
-          </div>
-        </Card>
-      </div>
+        }
+        description="Connect your Gmail account to view detailed analytics, track content performance, and get insights on your content strategy."
+        buttonColor="bg-red-500"
+        buttonHoverColor="hover:bg-red-600"
+      />
     );
   }
 
@@ -183,25 +165,13 @@ export function GmailPlatform({
             </div>
             
             <h3 className="text-lg sm:text-xl font-semibold text-gray-900 mb-2 sm:mb-3">
-              Connect Your Gmail Account
+              No Emails Found
             </h3>
             
             <p className="text-gray-600 mb-4 sm:mb-6 text-sm leading-relaxed">
-              Connect your Gmail account to view email analytics, track business communications, 
-              and get insights on partnership opportunities.
+              We couldn't find any emails in your connected Gmail account. 
+              Try sending or receiving emails to see your analytics here.
             </p>
-            
-            <Button 
-              onClick={() => router.push('/settings?tab=integrations')}
-              className="w-full py-3 px-4 sm:px-6 bg-red-500 hover:bg-red-600 text-white font-medium rounded-lg transition-all duration-200 flex items-center justify-center gap-2 text-sm sm:text-base"
-            >
-              <Settings className="w-4 h-4" />
-              Go to Integrations
-            </Button>
-            
-            <div className="mt-3 sm:mt-4 text-xs text-gray-500">
-              You can connect Gmail in Settings → Integrations
-            </div>
           </Card>
         </div>
       )}

--- a/src/app/dashboard/content-analytics/platforms/InstagramPlatform.tsx
+++ b/src/app/dashboard/content-analytics/platforms/InstagramPlatform.tsx
@@ -13,6 +13,7 @@ import { InstagramContentItem, AnyContentItem } from '../types';
 import { sortContent } from '../utils';
 import CardSkeleton from './components/CardSkeleton';
 import PieChartSkeleton from './components/PieChartSkeleton';
+import { PlatformConnectionPrompt } from '../../_components/content-hub/PlatformConnectionPrompt';
 
 interface InstagramPlatformProps {
   userId: string;
@@ -65,36 +66,17 @@ export function InstagramPlatform({
   // Show Instagram connect card if no Instagram account found
   if (!isConnected) {
     return (
-      <div className="flex items-center justify-center min-h-[400px] px-4">
-        <Card className="p-6 sm:p-8 max-w-md w-full bg-gradient-to-br from-white/80 to-white/60 backdrop-blur-sm border-0 shadow-lg rounded-2xl text-center">
-          <div className="flex justify-center mb-4 sm:mb-6">
-            <div className="w-12 h-12 sm:w-16 sm:h-16 rounded-full bg-gradient-to-r from-purple-500 to-pink-500 flex items-center justify-center">
-              <Instagram className="w-6 h-6 sm:w-8 sm:h-8 text-white" />
-            </div>
+      <PlatformConnectionPrompt
+        platformName="Instagram"
+        platformIcon={
+          <div className="w-12 h-12 sm:w-16 sm:h-16 rounded-full bg-gradient-to-r from-purple-500 to-pink-500 flex items-center justify-center">
+            <Instagram className="w-6 h-6 sm:w-8 sm:h-8 text-white" />
           </div>
-          
-          <h3 className="text-lg sm:text-xl font-semibold text-gray-900 mb-2 sm:mb-3">
-            Connect Your Instagram Account
-          </h3>
-          
-          <p className="text-gray-600 mb-4 sm:mb-6 text-sm leading-relaxed">
-            Connect your Instagram account to view detailed analytics, engagement insights, 
-            and content performance metrics.
-          </p>
-          
-          <Button 
-            onClick={() => router.push('/settings?tab=integrations')}
-            className="w-full py-3 px-4 sm:px-6 bg-gradient-to-r from-purple-500 to-pink-500 hover:from-purple-600 hover:to-pink-600 text-white font-medium rounded-lg transition-all duration-200 flex items-center justify-center gap-2 text-sm sm:text-base"
-          >
-            <Settings className="w-4 h-4" />
-            Go to Integrations
-          </Button>
-          
-          <div className="mt-3 sm:mt-4 text-xs text-gray-500">
-            You can connect Instagram in Settings → Integrations
-          </div>
-        </Card>
-      </div>
+        }
+        description="Connect your Instagram account to view detailed analytics, track content performance, and get insights on your content strategy."
+        buttonColor="bg-gradient-to-r from-purple-500 to-pink-500"
+        buttonHoverColor="hover:from-purple-600 hover:to-pink-600"
+      />
     );
   }
 

--- a/src/app/dashboard/content-analytics/platforms/YouTubePlatform.tsx
+++ b/src/app/dashboard/content-analytics/platforms/YouTubePlatform.tsx
@@ -13,6 +13,7 @@ import { YouTubeContentItem, AnyContentItem } from '../types';
 import { sortContent } from '../utils';
 import { YouTubeBrandIcon } from '../../../../lib/YoutubeBrandIcon';
 import { Skeleton } from '@/components/ui/skeleton';
+import { PlatformConnectionPrompt } from '../../_components/content-hub/PlatformConnectionPrompt';
 
 interface YouTubePlatformProps {
   userId: string;
@@ -71,6 +72,22 @@ export function YouTubePlatform({
   };
 
   // Show YouTube connect card if no YouTube account found
+  if (!isConnected) {
+    return (
+      <PlatformConnectionPrompt
+        platformName="YouTube"
+        platformIcon={
+          <div className="w-12 h-12 sm:w-16 sm:h-16 flex items-center justify-center">
+            <YouTubeBrandIcon href="https://youtube.com/" className="w-full h-full" />
+          </div>
+        }
+        description="Connect your YouTube account to view detailed analytics, track video performance, and get insights on your content strategy."
+        buttonColor="bg-red-600"
+        buttonHoverColor="hover:bg-red-700"
+      />
+    );
+  }
+
   if (loading) {
     return (
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8 mt-8">
@@ -87,39 +104,6 @@ export function YouTubePlatform({
             </div>
           </div>
         ))}
-      </div>
-    );
-  }
-
-  if (!isConnected) {
-    return (
-      <div className="flex items-center justify-center min-h-[400px] px-4">
-        <Card className="p-6 sm:p-8 max-w-md w-full bg-gradient-to-br from-white/80 to-white/60 backdrop-blur-sm border-0 shadow-lg rounded-2xl text-center">
-          <div className="flex justify-center mb-4 sm:mb-6">
-            <YouTubeBrandIcon href="https://youtube.com/" className="w-16 h-16" />
-          </div>
-          
-          <h3 className="text-lg sm:text-xl font-semibold text-gray-900 mb-2 sm:mb-3">
-            Connect Your YouTube Channel
-          </h3>
-          
-          <p className="text-gray-600 mb-4 sm:mb-6 text-sm leading-relaxed">
-            Connect your YouTube channel to view detailed analytics, track video performance, 
-            and get insights on your content strategy.
-          </p>
-          
-          <Button 
-            onClick={() => router.push('/settings?tab=integrations')}
-            className="w-full py-3 px-4 sm:px-6 bg-red-600 hover:bg-red-700 text-white font-medium rounded-lg transition-all duration-200 flex items-center justify-center gap-2 text-sm sm:text-base"
-          >
-            <Settings className="w-4 h-4" />
-            Go to Integrations
-          </Button>
-          
-          <div className="mt-3 sm:mt-4 text-xs text-gray-500">
-            You can connect YouTube in Settings → Integrations
-          </div>
-        </Card>
       </div>
     );
   }


### PR DESCRIPTION
Added a component that allows the user to go to integrations from content hub if they are not connect to that platform.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a unified connection prompt card for YouTube, Instagram, and Gmail, guiding users to connect their platforms with clear messaging and a direct link to integration settings.
- **Enhancements**
  - Improved empty state visuals and messages for analytics and insights when no platforms are connected, using updated styling and icons.
  - Refined messaging and presentation for empty content states, providing clearer guidance and a more visually appealing experience.
  - Updated YouTube brand icon links to direct users to the official YouTube website.
- **Refactor**
  - Consolidated platform connection prompts into a reusable component for consistency across the dashboard.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->