### PR TITLE
Changing profile picture to be optional

### DIFF
--- a/convex/http.ts
+++ b/convex/http.ts
@@ -995,7 +995,7 @@ try {
         id: string;
         username: string;
         account_type: any;
-        profile_picture_url: any;
+        profile_picture_url?: any;
         followers_count: any;
         follows_count: any;
         media_count: any;

--- a/convex/instagramMutations.ts
+++ b/convex/instagramMutations.ts
@@ -74,7 +74,7 @@ export const storeProfileData = mutation({
       id: v.string(),
       username: v.string(),
       account_type: v.any(),
-      profile_picture_url: v.any(),
+      profile_picture_url: v.optional(v.any()),
       followers_count: v.any(),
       follows_count: v.any(),
       media_count: v.any(),

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -495,7 +495,7 @@ export default defineSchema({
       id: v.string(),
       username: v.string(),
       account_type: v.any(),
-      profile_picture_url: v.any(),
+      profile_picture_url: v.optional(v.any()),
       followers_count: v.any(),
       follows_count: v.any(),
       media_count: v.any(),


### PR DESCRIPTION
Chaging values of schema https and mutations to make profile picture optional for instagram

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- The Instagram profile picture field is now optional, allowing profiles to be stored without a profile picture URL.
- **Bug Fixes**
	- Improved validation to prevent errors when the profile picture URL is missing from Instagram profile data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->