### PR TITLE
Update PersonaCardRenderer and PersonaTip components for improved nav…

### DIFF
--- a/src/app/dashboard/chat/components/PersonaCardRenderer.tsx
+++ b/src/app/dashboard/chat/components/PersonaCardRenderer.tsx
@@ -147,10 +147,10 @@ export const PersonaCardRenderer: React.FC<PersonaCardRendererProps> = ({ messag
           <div className="flex justify-center mt-6">
             <button
               className="px-4 py-2 bg-gray-900 text-white font-semibold rounded-lg shadow-sm hover:bg-gray-800 transition-colors"
-              onClick={() => router.push('/settings')}
+              onClick={() => router.push('/dashboard/self-hub')}
               type="button"
             >
-              View Persona in Settings
+              View Persona in Self
             </button>
           </div>
         )}

--- a/src/app/dashboard/chat/components/PersonaTip.tsx
+++ b/src/app/dashboard/chat/components/PersonaTip.tsx
@@ -20,7 +20,7 @@ export const PersonaTip: React.FC<PersonaTipProps> = ({ onTipClick }) => {
   };
 
   return (
-    <div className="fixed left-4 bottom-24 z-10">
+    <div className="fixed right-4 bottom-24 z-10">
       {isExpanded ? (
         <div className="bg-white border border-gray-200 rounded-lg shadow-lg p-4 max-w-xs w-64 animate-in fade-in-20 slide-in-from-bottom-4 duration-300">
           <div className="flex justify-between items-start mb-2">


### PR DESCRIPTION
…igation and layout

- Changed button action in PersonaCardRenderer to redirect to '/dashboard/self-hub' and updated button text to 'View Persona in Self'.
- Adjusted positioning of the PersonaTip component from left to right for better visibility.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - Updated button in the persona card to navigate to "Self Hub" with a new label.
  - Moved the persona tip UI from the bottom-left to the bottom-right corner of the screen.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->