### PR TITLE
Refactor quoted content handling in MarkdownNotepad to preserve markdown formatting. Cleaned leading/trailing quotes from quoted content before insertion.

### DIFF
--- a/src/app/dashboard/chat/components/notepad/MarkdownNotepad.tsx
+++ b/src/app/dashboard/chat/components/notepad/MarkdownNotepad.tsx
@@ -55,7 +55,9 @@ export function MarkdownNotepad({
   // Handle quoted content insertion
   useEffect(() => {
     if (quotedContent && isOpen) {
-      const quotedText = `> ${quotedContent.replace(/\n/g, '\n> ')}\n\n`
+      // Remove only leading/trailing quotes while preserving all markdown formatting (bold, italics, etc.) and newlines
+      const cleanedContent = quotedContent.replace(/^["']|["']$/g, '').trim()
+      const quotedText = `${cleanedContent}\n\n`
       setContent(prev => prev + quotedText)
       onClearQuoted?.()
     }


### PR DESCRIPTION
This pull request includes a small change to the `MarkdownNotepad` component to improve how quoted content is handled. Specifically, it modifies the logic to remove only leading and trailing quotes from the quoted content while preserving markdown formatting and newlines

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated how quoted content is inserted in the notepad to preserve original markdown formatting and newlines, without automatically converting it into a blockquote.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->