### PR TITLE
feat: enhance chat history display and add relative time formatting

### DIFF
--- a/src/app/api/chat/history/route.ts
+++ b/src/app/api/chat/history/route.ts
@@ -89,11 +89,19 @@ export async function GET(request: Request) {
         ? cleanMessageContent(firstMessage.content, firstMessage.role)
         : 'No preview available';
 
+      console.log(`[${requestId}] Processing conversation:`, {
+        id: conv._id,
+        title: conv.title,
+        _creationTime: conv._creationTime,
+        createdAt: conv.createdAt
+      });
+
       return {
         id: conv._id,
         topic: conv.title || 'Untitled Chat',
         preview: cleanedPreview,
         starred: conv.starred || false,
+        createdAt: conv._creationTime || conv.createdAt,
         messages: conv.messages?.map((msg, index) => ({
           id: index,
           content: cleanMessageContent(msg.content, msg.role),

--- a/src/app/dashboard/_components/dashboard-nav.tsx
+++ b/src/app/dashboard/_components/dashboard-nav.tsx
@@ -36,7 +36,25 @@ interface ChatHistory {
   id: string;
   topic: string;
   preview?: string;
+  createdAt?: number;
 }
+
+// Helper function to format relative time
+const formatRelativeTime = (timestamp: number): string => {
+  const now = Date.now();
+  const diffMs = now - timestamp;
+  const diffMinutes = Math.floor(diffMs / (1000 * 60));
+  const diffHours = Math.floor(diffMs / (1000 * 60 * 60));
+  const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
+
+  if (diffMinutes < 1) return 'Just now';
+  if (diffMinutes < 60) return `${diffMinutes}m ago`;
+  if (diffHours < 24) return `${diffHours}h ago`;
+  if (diffDays < 7) return `${diffDays}d ago`;
+  
+  // For older chats, show the actual date
+  return new Date(timestamp).toLocaleDateString();
+};
 
 export const DashboardNav = memo(function DashboardNav() {
   const pathname = usePathname()
@@ -66,7 +84,9 @@ export const DashboardNav = memo(function DashboardNav() {
       
       if (response.ok) {
         const data = await response.json();
+        console.log('Chat history API response:', data);
         if (data.conversations) {
+          console.log('Recent chats data:', data.conversations);
           setRecentChats(data.conversations);
         }
       }
@@ -232,7 +252,16 @@ export const DashboardNav = memo(function DashboardNav() {
                     title={chat.topic}
                   >
                     <Clock className="w-4 h-4 text-muted-foreground shrink-0" />
-                    <span className="text-sm text-foreground truncate">{chat.topic}</span>
+                    <div className="flex flex-col flex-1 min-w-0">
+                      <span className="text-sm text-foreground truncate">{chat.topic}</span>
+                      {chat.createdAt ? (
+                        <span className="text-xs text-muted-foreground">
+                          {formatRelativeTime(chat.createdAt)}
+                        </span>
+                      ) : (
+                        <span className="text-xs text-red-500">No timestamp</span>
+                      )}
+                    </div>
                   </Link>
                 ))
               ) : (

--- a/src/app/dashboard/history/page.tsx
+++ b/src/app/dashboard/history/page.tsx
@@ -7,11 +7,30 @@ import {
   Search,
   MessageSquare,
   Trash2,
-  Star
+  Star,
+  Clock
 } from 'lucide-react'
 import { ChatHistory } from '@/app/types/chat'
 import { getApiKey } from '@/app/lib/api-helpers'
 import { Skeleton } from '@/components/ui/skeleton'
+
+// Helper function to format relative time
+const formatRelativeTime = (timestamp: string | number): string => {
+  const now = Date.now();
+  const time = typeof timestamp === 'string' ? new Date(timestamp).getTime() : timestamp;
+  const diffMs = now - time;
+  const diffMinutes = Math.floor(diffMs / (1000 * 60));
+  const diffHours = Math.floor(diffMs / (1000 * 60 * 60));
+  const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
+
+  if (diffMinutes < 1) return 'Just now';
+  if (diffMinutes < 60) return `${diffMinutes}m ago`;
+  if (diffHours < 24) return `${diffHours}h ago`;
+  if (diffDays < 7) return `${diffDays}d ago`;
+  
+  // For older chats, show the actual date
+  return new Date(time).toLocaleDateString();
+};
 
 export default function HistoryPage() {
   const router = useRouter()
@@ -148,10 +167,18 @@ export default function HistoryPage() {
                 >
                   <div className="flex items-start gap-3">
                     <MessageSquare className="w-5 h-5 text-muted-foreground/70 shrink-0 mt-0.5" />
-                    <div className="overflow-hidden">
-                      <h3 className="font-medium text-foreground/90 truncate">{chat.topic}</h3>
+                    <div className="overflow-hidden flex-1">
+                      <div className="flex items-center justify-between gap-3 mb-1">
+                        <h3 className="font-medium text-foreground/90 truncate">{chat.topic}</h3>
+                        {chat.createdAt && (
+                          <div className="flex items-center gap-1 text-xs text-muted-foreground/60 shrink-0">
+                            <Clock className="w-3 h-3" />
+                            <span>{formatRelativeTime(chat.createdAt)}</span>
+                          </div>
+                        )}
+                      </div>
                       {chat.preview && (
-                        <p className="text-sm text-muted-foreground/80 mt-1 line-clamp-1">
+                        <p className="text-sm text-muted-foreground/80 line-clamp-1">
                           {chat.preview}
                         </p>
                       )}

--- a/src/app/types/chat.ts
+++ b/src/app/types/chat.ts
@@ -53,7 +53,7 @@ export interface Message {
 export interface ChatHistory {
   id: string;
   messages: Message[];
-  createdAt: string;
+  createdAt: string | number;
   updatedAt: string;
   title?: string;
   topic: string;


### PR DESCRIPTION
- Added a `createdAt` field to the ChatHistory interface to store message creation timestamps.
- Implemented a helper function to format timestamps into relative time strings for better user experience.
- Updated the DashboardNav and HistoryPage components to display the formatted creation time of chats.
- Enhanced logging for chat history API responses to aid in debugging.

Closes: Improvements to chat history presentation and usability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Recent chat conversations now display a relative time indicator (e.g., "5m ago", "2d ago") alongside the chat topic in both the dashboard navigation and chat history views.
  - A clock icon visually accompanies the relative time in the chat history list.

- **Improvements**
  - If a chat entry lacks a timestamp, a clear "No timestamp" label is shown for better clarity.
  - Timestamp handling is now more flexible, supporting both string and numeric formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->