### PR TITLE
Refactor diff handling in YouTube mutations to remove previous value …

### DIFF
--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -397,7 +397,6 @@ export default defineSchema({
     diffs: v.optional(v.array(v.object({
       changedAt: v.number(),
       changedFields: v.array(v.string()),
-      previous: v.any(),
       current: v.any(),
       changeType: v.optional(v.string()),
     })))
@@ -494,7 +493,6 @@ export default defineSchema({
     diffs: v.optional(v.array(v.object({
       changedAt: v.number(),
       changedFields: v.array(v.string()),
-      previous: v.any(),
       current: v.any(),
       changeType: v.optional(v.string()),
     })))

--- a/convex/youtubeMutations.ts
+++ b/convex/youtubeMutations.ts
@@ -4,18 +4,16 @@ import { api } from "./_generated/api";
 
 function calculateDiff(oldDoc, newDoc, excludeFields = []) {
   const changedFields = [];
-  const previous = {};
   const current = {};
   for (const key of Object.keys(newDoc)) {
     if (excludeFields.includes(key)) continue;
     if (JSON.stringify(oldDoc?.[key]) !== JSON.stringify(newDoc[key])) {
       changedFields.push(key);
-      previous[key] = oldDoc?.[key];
       current[key] = newDoc[key];
     }
   }
   return changedFields.length > 0
-    ? { changedFields, previous, current }
+    ? { changedFields, current }
     : null;
 }
 
@@ -62,10 +60,9 @@ export const storeVideoData = mutation({
     }
     // Do NOT overwrite statistics.comments with array length
 
-    // --- Clean diff logic: only changed field names and previous values ---
+    // --- Clean diff logic: only changed field names and current values ---
     function cleanDiff(oldDoc, newDoc, excludeFields = []) {
       const changedFields = [];
-      const previous = {};
       const current = {};
       for (const key of Object.keys(newDoc)) {
         if (excludeFields.includes(key)) continue;
@@ -78,17 +75,14 @@ export const storeVideoData = mutation({
             const newComments = Array.isArray(newDoc.comments.comments) ? newDoc.comments.comments : [];
             const oldIds = new Set(oldComments.map(c => c.id));
             const added = newComments.filter(c => !oldIds.has(c.id));
-            // Optionally, you could also diff by content, likes, etc. for edits
-            previous[key] = { count: oldComments.length };
             current[key] = { added, count: newComments.length };
           } else {
-            previous[key] = oldDoc?.[key];
             current[key] = newDoc[key];
           }
         }
       }
       return changedFields.length > 0
-        ? { changedFields, previous, current }
+        ? { changedFields, current }
         : null;
     }
 
@@ -103,7 +97,6 @@ export const storeVideoData = mutation({
       const newDiff = {
         changedAt: now,
         changedFields: diff.changedFields,
-        previous: diff.previous,
         current: diff.current,
         changeType: "update"
       };
@@ -181,7 +174,6 @@ export const saveChannelData = mutation({
       const newDiff = {
         changedAt: updatedAt,
         changedFields: diff.changedFields,
-        previous: diff.previous,
         current: diff.current,
         changeType: "update"
       };
@@ -244,7 +236,6 @@ export const storeVideoAnalysis = mutation({
       const newDiff = {
         changedAt: now,
         changedFields: [changedField],
-        previous: { [changedField]: "changed" },
         current: { [changedField]: "changed" },
         changeType: "analysis"
       };
@@ -315,7 +306,6 @@ export const storeChannelAnalysis = mutation({
       const newDiff = {
         changedAt: now,
         changedFields: ["analysis"],
-        previous: { analysis: "changed" },
         current: { analysis: "changed" },
         changeType: "analysis"
       };


### PR DESCRIPTION
…tracking

- Removed the 'previous' field from diff calculations in YouTube mutations and schema.
- Updated related functions to only track 'current' values for changed fields.
- Simplified the diff logic to enhance clarity and maintainability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified the change tracking for YouTube channels and videos by removing the display of previous values in change histories. Now, only the current values and changed fields are shown in diff records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->