### PR TITLE
[feat] Add debug endpoint to list all Instagram accounts

### DIFF
--- a/convex/http.ts
+++ b/convex/http.ts
@@ -2133,5 +2133,22 @@ app.post("/api/instagram/story/insights", async (c) => {
   }
 });
 
+// Debug endpoint to list all Instagram accounts (for troubleshooting)
+app.get("/api/debug/instagram/accounts", async (c) => {
+  const ctx = c.env;
+  
+  try {
+    const accounts = await ctx.runQuery(api.instagramQueries.getAllInstagramAccounts, {});
+    return c.json({ 
+      success: true, 
+      accounts,
+      count: accounts.length
+    });
+  } catch (error) {
+    console.error("Debug endpoint error:", error);
+    return c.json({ success: false, error: "Debug endpoint error" }, 500);
+  }
+});
+
 const router = new HttpRouterWithHono(app);
 export default router;

--- a/convex/instagramQueries.ts
+++ b/convex/instagramQueries.ts
@@ -955,3 +955,26 @@ export const getInstagramPostByMediaId = query({
     }
   },
 });
+
+// Get all Instagram accounts (for debugging)
+export const getAllInstagramAccounts = query({
+  args: {},
+  handler: async (ctx, args) => {
+    try {
+      const accounts = await ctx.db
+        .query("instagramAccounts")
+        .collect();
+      
+      return accounts.map(account => ({
+        userId: account.userId,
+        instagramAccountId: account.instagramAccountId,
+        username: account.username,
+        createdAt: account.createdAt,
+        updatedAt: account.updatedAt
+      }));
+    } catch (error) {
+      console.error('Error getting all Instagram accounts:', error);
+      throw new Error(`Failed to get Instagram accounts: ${error instanceof Error ? error.message : 'Unknown error'}`);
+    }
+  },
+});


### PR DESCRIPTION
## Summary of Changes

This PR introduces a debug endpoint to facilitate troubleshooting and verification of Instagram account connections. It adds a new API endpoint and a corresponding Convex query to retrieve a list of all connected Instagram accounts. This enhancement simplifies debugging by providing a direct method to inspect the state of Instagram integrations.

## Key Changes

This PR aims to improve the debuggability of Instagram account integrations.

-   A new GET endpoint `/api/debug/instagram/accounts` was added to [`convex/http.ts`](heycontent-web/convex/http.ts:2134). This endpoint allows developers to retrieve a list of all connected Instagram accounts.
-   A new query `getAllInstagramAccounts` was added to [`convex/instagramQueries.ts`](heycontent-web/instagramQueries.ts:955). This query fetches all Instagram accounts from the database.

These changes are beneficial because they provide a simple and direct way to verify Instagram account connections, which can be useful for troubleshooting and debugging purposes. This addition does not affect system performance or scalability, as it is intended for debugging purposes only and should not be used in production code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new debug endpoint to view all Instagram accounts, returning account details and total count in a JSON response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->