### PR TITLE
Removing title prop from HelpModal

### DIFF
--- a/src/app/dashboard/_components/content-hub/ContentHubScreen.tsx
+++ b/src/app/dashboard/_components/content-hub/ContentHubScreen.tsx
@@ -749,7 +749,6 @@ export function ContentHubScreen() {
         open={helpOpen} 
         onClose={() => setHelpOpen(false)} 
         pages={contentHubHelp}
-        title="Content Hub Guide"
       />
     </div>
   )

--- a/src/app/dashboard/chat/ChatContainer.tsx
+++ b/src/app/dashboard/chat/ChatContainer.tsx
@@ -744,7 +744,6 @@ const ChatContainer: React.FC<ChatScreenProps> = ({ chatId, contentContext, askQ
         open={helpOpen} 
         onClose={() => setHelpOpen(false)} 
         pages={chatHelp}
-        title="Chat Guide"
       />
     </>
   );

--- a/src/app/dashboard/notes/index.tsx
+++ b/src/app/dashboard/notes/index.tsx
@@ -350,7 +350,6 @@ export default function SmartNotes() {
         open={helpOpen} 
         onClose={() => setHelpOpen(false)} 
         pages={notesHelp}
-        title="Smart Notes Guide"
       />
     </div>
   );

--- a/src/app/dashboard/self-hub/page.tsx
+++ b/src/app/dashboard/self-hub/page.tsx
@@ -67,7 +67,6 @@ export default function SelfHubPage() {
         open={helpOpen} 
         onClose={() => setHelpOpen(false)} 
         pages={selfHubHelp}
-        title="Self Hub Guide"
       />
     </div>
   );

--- a/src/app/settings/SettingsScreen.tsx
+++ b/src/app/settings/SettingsScreen.tsx
@@ -181,7 +181,6 @@ const SettingsScreen = () => {
         open={helpOpen} 
         onClose={() => setHelpOpen(false)} 
         pages={settingsHelp}
-        title="Settings Guide"
       />
     </div>
   )


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated help modals across multiple screens by removing guide titles from their display. No changes to app functionality or user flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->