### PR TITLE
fix: Improve markdown content cleaning in MarkdownNotepad

### DIFF
--- a/src/app/dashboard/chat/components/notepad/MarkdownNotepad.tsx
+++ b/src/app/dashboard/chat/components/notepad/MarkdownNotepad.tsx
@@ -56,7 +56,12 @@ export const MarkdownNotepad = forwardRef(function MarkdownNotepad({
   useEffect(() => {
     if (quotedContent && isOpen) {
       // Remove only leading/trailing quotes while preserving all markdown formatting (bold, italics, etc.) and newlines
-      const cleanedContent = quotedContent.replace(/^["']|["']$/g, '').trim()
+      let cleanedContent = quotedContent.replace(/^['"]|['"]$/g, '').trim()
+      // Remove leading '>' and whitespace from each line
+      cleanedContent = cleanedContent
+        .split('\n')
+        .map(line => line.replace(/^\s*>\s?/, ''))
+        .join('\n')
       const quotedText = `${cleanedContent}\n\n`
       setContent(prev => prev + quotedText)
       onClearQuoted?.()


### PR DESCRIPTION
- Enhanced the content cleaning process by removing leading/trailing quotes and leading '>' characters from each line.
- Ensured that markdown formatting is preserved while cleaning up quoted content for better readability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved handling of quoted content in the notepad by automatically removing markdown blockquote markers from each line when adding quoted text.

* **Bug Fixes**
  * Quoted text added to the notepad now appears without unnecessary blockquote formatting, improving readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->