### PR TITLE
Renaming instagram refresh button

### DIFF
--- a/src/app/dashboard/content-analytics/platforms/InstagramPlatform.tsx
+++ b/src/app/dashboard/content-analytics/platforms/InstagramPlatform.tsx
@@ -178,7 +178,7 @@ export function InstagramPlatform({
             className="bg-white/80 hover:bg-white border border-gray-200 text-gray-700 hover:text-gray-900 backdrop-blur-sm"
           >
             <RefreshCw className={`w-4 h-4 mr-2 ${refreshing ? 'animate-spin' : ''}`} />
-            {refreshing ? 'Refreshing Analytics & Posts...' : 'Refresh Instagram'}
+            {refreshing ? 'Refreshing Instagram...' : 'Refresh Instagram'}
           </Button>
         </div>
 

--- a/src/app/dashboard/content-analytics/platforms/InstagramPlatform.tsx
+++ b/src/app/dashboard/content-analytics/platforms/InstagramPlatform.tsx
@@ -178,7 +178,7 @@ export function InstagramPlatform({
             className="bg-white/80 hover:bg-white border border-gray-200 text-gray-700 hover:text-gray-900 backdrop-blur-sm"
           >
             <RefreshCw className={`w-4 h-4 mr-2 ${refreshing ? 'animate-spin' : ''}`} />
-            {refreshing ? 'Refreshing Analytics & Posts...' : 'Refresh Analytics & Posts'}
+            {refreshing ? 'Refreshing Analytics & Posts...' : 'Refresh Instagram'}
           </Button>
         </div>
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated the refresh button label in the Instagram analytics dashboard to "Refresh Instagram" when not refreshing.
  * Changed the refresh button label to "Refreshing Instagram..." during the refresh process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->