### PR TITLE
fix: Handle missing thread subject and date in InsightCard component

### DIFF
--- a/src/app/dashboard/ai-insights/_components/InsightCard.tsx
+++ b/src/app/dashboard/ai-insights/_components/InsightCard.tsx
@@ -248,10 +248,12 @@ ${relatedItems && relatedItems.length > 0 ? `### Related Items\n${relatedItems.m
                   >
                     <div className="flex items-start justify-between">
                       <span className="flex-1 mr-2">
-                        • {thread.subject.startsWith('Re: ') ? thread.subject : `Re: ${thread.subject}`}
+                        • {thread.subject
+                            ? (thread.subject.startsWith('Re: ') ? thread.subject : `Re: ${thread.subject}`)
+                            : 'No Subject'}
                       </span>
                       <span className="text-xs text-gray-500 dark:text-gray-500 whitespace-nowrap">
-                        ({thread.date})
+                        ({thread.date || 'Unknown Date'})
                       </span>
                     </div>
                   </div>


### PR DESCRIPTION
- Added a fallback for thread subject to display 'No Subject' when it is not provided.
- Updated date display to show 'Unknown Date' if the thread date is missing, enhancing user experience and clarity.