### PR TITLE
refactor: Optimize Gmail, Instagram, and YouTube insights hooks

### DIFF
--- a/src/app/dashboard/ai-insights/_components/hooks/useGmailInsights.ts
+++ b/src/app/dashboard/ai-insights/_components/hooks/useGmailInsights.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect } from 'react';
+import { useState, useCallback, useEffect, useMemo } from 'react';
 import { useQuery, useMutation } from "convex/react";
 import { api } from "@/convex/_generated/api";
 import { getApiKey } from '@/app/lib/api-helpers';
@@ -17,29 +17,27 @@ export function useGmailInsights(userId?: string): BatchAnalysisHookReturn {
     userId ? { userId } : "skip"
   );
 
+  // Memoize the accountId to avoid unnecessary re-renders
+  const gmailAccountId = useMemo(
+    () => (gmailAccount && gmailAccount.length > 0 ? gmailAccount[0].email : undefined),
+    [gmailAccount]
+  );
+
   // Fetch Gmail batch analysis insights
   const gmailInsights = useQuery(
     api.gmailQueries.getGmailBatchAnalysis,
-    userId && gmailAccount && gmailAccount.length > 0 ? { 
+    userId && gmailAccountId ? { 
       userId, 
-      gmailAccountId: gmailAccount[0].email 
+      gmailAccountId
     } : "skip"
   );
 
   // Store Gmail batch analysis mutation
   const storeGmailBatchAnalysis = useMutation(api.gmailMutations.storeGmailBatchAnalysis);
 
-  // Extract data - handle both old and new formats during transition
-  console.log('[useGmailInsights] Raw Convex data:', gmailInsights);
-  console.log('[useGmailInsights] gmailInsights?.insights:', gmailInsights?.insights);
-  console.log('[useGmailInsights] Type of gmailInsights?.insights:', typeof gmailInsights?.insights);
-  console.log('[useGmailInsights] Is array?', Array.isArray(gmailInsights?.insights));
-  
   // Check if insights is the universal format object (with insights, metadata, status)
   const rawInsights = gmailInsights?.insights;
   const isUniversalFormat = rawInsights && typeof rawInsights === 'object' && 'insights' in rawInsights;
-  
-  console.log('[useGmailInsights] Is universal format?', isUniversalFormat);
   
   const insightsList: InsightCard[] = isUniversalFormat 
     ? (rawInsights as any).insights || []
@@ -51,10 +49,6 @@ export function useGmailInsights(userId?: string): BatchAnalysisHookReturn {
     ? (rawInsights as any).status || null
     : gmailInsights?.status || null;
     
-  console.log('[useGmailInsights] Extracted insightsList:', insightsList);
-  console.log('[useGmailInsights] Extracted metadata:', metadata);
-  console.log('[useGmailInsights] Extracted status:', status);
-
   // Only show as running if we're actively refreshing AND status is processing/enqueued
   // Don't auto-show loading for old stuck statuses
   // Check both root-level status (updated by mutations) and nested status (from insights)
@@ -73,21 +67,6 @@ export function useGmailInsights(userId?: string): BatchAnalysisHookReturn {
   // Once database status updates to processing/enqueued, continue showing refreshing state
   const isActuallyRunning = isRefreshing || databaseStatus === 'processing' || databaseStatus === 'enqueued' || databaseStatus === 'running';
   
-  console.log('[useGmailInsights] Refresh state debug:', {
-    localIsRefreshing: isRefreshing,
-    rootStatus,
-    nestedStatus,
-    databaseStatus,
-    isActuallyRunning,
-    status: status,
-    rootStatusObject: gmailInsights?.status,
-    currentProgress,
-    rootProgress: gmailInsights?.status?.progress,
-    nestedProgress: status?.progress,
-    hasAccount: !!(gmailAccount && gmailAccount.length > 0),
-    hasInsights: !!insightsList?.length
-  });
-
   // Check if there's an error in the batch analysis
   const batchError = status?.error;
 
@@ -103,11 +82,9 @@ export function useGmailInsights(userId?: string): BatchAnalysisHookReturn {
     if (isRefreshing && databaseStatus) {
       if (databaseStatus === 'completed' || databaseStatus === 'failed') {
         // Task definitively finished - clear local state
-        console.log('[useGmailInsights] Task completed/failed, clearing local refresh state');
         setIsRefreshing(false);
       } else if (databaseStatus === 'processing' || databaseStatus === 'enqueued' || databaseStatus === 'running') {
         // Database caught up with our refresh request - database now drives the state
-        console.log('[useGmailInsights] Database status updated to active, local state can continue');
       }
     }
   }, [isRefreshing, databaseStatus]);
@@ -120,22 +97,9 @@ export function useGmailInsights(userId?: string): BatchAnalysisHookReturn {
 
     // Prevent multiple concurrent refresh attempts
     if (isRefreshing || databaseStatus === 'processing' || databaseStatus === 'enqueued' || databaseStatus === 'running') {
-      console.log('[useGmailInsights] Refresh already in progress, ignoring click', {
-        isRefreshing,
-        databaseStatus,
-        currentTime: new Date().toISOString()
-      });
       return;
     }
 
-    console.log('[useGmailInsights] Starting refresh...', {
-      userId,
-      hasAccount: !!(gmailAccount && gmailAccount.length > 0),
-      threadLimit,
-      currentTime: new Date().toISOString()
-    });
-
-    // Set local refreshing state
     setIsRefreshing(true);
     setError(null);
     
@@ -173,9 +137,6 @@ export function useGmailInsights(userId?: string): BatchAnalysisHookReturn {
       if (data.status === 'enqueued') {
         // Gmail analysis is now async - the status is tracked in the database
         // The results will be automatically available in the query once completed
-        console.log(`✅ Gmail analysis enqueued with task ID: ${data.task_id}`);
-        console.log('[useGmailInsights] Task enqueued, keeping local refresh state until database updates');
-        // Keep refreshing state until task completes - database will update via real-time subscription
       } else if (data.status === 'success') {
         // Handle legacy synchronous response (if any)
         await storeGmailBatchAnalysis({

--- a/src/app/dashboard/ai-insights/_components/hooks/useInstagramInsights.ts
+++ b/src/app/dashboard/ai-insights/_components/hooks/useInstagramInsights.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect } from 'react';
+import { useState, useCallback, useEffect, useMemo } from 'react';
 import { useQuery, useMutation } from "convex/react";
 import { api } from "@/convex/_generated/api";
 import { getApiKey } from '@/app/lib/api-helpers';
@@ -17,12 +17,18 @@ export function useInstagramInsights(userId?: string): BatchAnalysisHookReturn {
     userId ? { userId } : "skip"
   );
 
+  // Memoize the accountId to avoid unnecessary re-renders
+  const instagramAccountId = useMemo(
+    () => instagramAccount?.instagramAccountId,
+    [instagramAccount]
+  );
+
   // Fetch Instagram batch analysis insights
   const instagramInsights = useQuery(
     api.instagramQueries.getInstagramBatchAnalysis,
-    userId && instagramAccount?.instagramAccountId ? { 
+    userId && instagramAccountId ? { 
       userId, 
-      instagramAccountId: instagramAccount.instagramAccountId 
+      instagramAccountId
     } : "skip"
   );
 
@@ -30,16 +36,9 @@ export function useInstagramInsights(userId?: string): BatchAnalysisHookReturn {
   const storeInstagramAnalysis = useMutation(api.instagramMutations.storeInstagramBatchAnalysis);
 
   // Extract data - handle both old and new formats during transition
-  console.log('[useInstagramInsights] Raw Convex data:', instagramInsights);
-  console.log('[useInstagramInsights] instagramInsights?.insights:', instagramInsights?.insights);
-  console.log('[useInstagramInsights] Type of instagramInsights?.insights:', typeof instagramInsights?.insights);
-  console.log('[useInstagramInsights] Is array?', Array.isArray(instagramInsights?.insights));
-  
   // Check if insights is the universal format object (with insights, metadata, status)
   const rawInsights = instagramInsights?.insights;
   const isUniversalFormat = rawInsights && typeof rawInsights === 'object' && 'insights' in rawInsights;
-  
-  console.log('[useInstagramInsights] Is universal format?', isUniversalFormat);
   
   const insightsList: InsightCard[] = isUniversalFormat 
     ? (rawInsights as any).insights || []
@@ -51,10 +50,6 @@ export function useInstagramInsights(userId?: string): BatchAnalysisHookReturn {
     ? (rawInsights as any).status || null
     : instagramInsights?.status || null;
     
-  console.log('[useInstagramInsights] Extracted insightsList:', insightsList);
-  console.log('[useInstagramInsights] Extracted metadata:', metadata);
-  console.log('[useInstagramInsights] Extracted status:', status);
-
   // Only show as running if we're actively refreshing AND status is processing/enqueued
   // Don't auto-show loading for old stuck statuses
   // Check both root-level status (updated by mutations) and nested status (from insights)
@@ -73,21 +68,6 @@ export function useInstagramInsights(userId?: string): BatchAnalysisHookReturn {
   // Once database status updates to processing/enqueued, continue showing refreshing state
   const isActuallyRunning = isRefreshing || databaseStatus === 'processing' || databaseStatus === 'enqueued' || databaseStatus === 'running';
   
-  console.log('[useInstagramInsights] Refresh state debug:', {
-    localIsRefreshing: isRefreshing,
-    rootStatus,
-    nestedStatus,
-    databaseStatus,
-    isActuallyRunning,
-    status: status,
-    rootStatusObject: instagramInsights?.status,
-    currentProgress,
-    rootProgress: instagramInsights?.status?.progress,
-    nestedProgress: status?.progress,
-    hasAccount: !!instagramAccount?.instagramAccountId,
-    hasInsights: !!insightsList?.length
-  });
-
   // Check if there's an error in the batch analysis
   const batchError = status?.error;
 
@@ -103,11 +83,9 @@ export function useInstagramInsights(userId?: string): BatchAnalysisHookReturn {
     if (isRefreshing && databaseStatus) {
       if (databaseStatus === 'completed' || databaseStatus === 'failed') {
         // Task definitively finished - clear local state
-        console.log('[useInstagramInsights] Task completed/failed, clearing local refresh state');
         setIsRefreshing(false);
       } else if (databaseStatus === 'processing' || databaseStatus === 'enqueued' || databaseStatus === 'running') {
         // Database caught up with our refresh request - database now drives the state
-        console.log('[useInstagramInsights] Database status updated to active, local state can continue');
       }
     }
   }, [isRefreshing, databaseStatus]);
@@ -120,22 +98,9 @@ export function useInstagramInsights(userId?: string): BatchAnalysisHookReturn {
 
     // Prevent multiple concurrent refresh attempts
     if (isRefreshing || databaseStatus === 'processing' || databaseStatus === 'enqueued' || databaseStatus === 'running') {
-      console.log('[useInstagramInsights] Refresh already in progress, ignoring click', {
-        isRefreshing,
-        databaseStatus,
-        currentTime: new Date().toISOString()
-      });
       return;
     }
 
-    console.log('[useInstagramInsights] Starting refresh...', {
-      userId,
-      hasAccount: !!instagramAccount?.instagramAccountId,
-      postLimit,
-      currentTime: new Date().toISOString()
-    });
-
-    // Set local refreshing state
     setIsRefreshing(true);
     setError(null);
     
@@ -172,32 +137,10 @@ export function useInstagramInsights(userId?: string): BatchAnalysisHookReturn {
       if (data.status === 'enqueued') {
         // Instagram analysis is now async - the status is tracked in the database
         // The results will be automatically available in the query once completed
-        console.log(`✅ Instagram analysis enqueued with task ID: ${data.task_id}`);
-        console.log('[useInstagramInsights] Task enqueued, keeping local refresh state until database updates');
-        // Keep refreshing state until task completes - database will update via real-time subscription
       } else if (data.status === 'success') {
         // Log optimization information
         if (data.analysis_summary) {
           const summary = data.analysis_summary;
-          console.log('📊 Instagram Insights Analysis Summary:', {
-            requestedPosts: summary.requested_posts,
-            actualPostsAnalyzed: summary.actual_posts_analyzed || summary.total_posts,
-            cachedPostsAvailable: summary.cached_posts_available,
-            optimizedApiUsage: summary.optimized_api_usage,
-            rateLimited: summary.rate_limited,
-            fallbackToCache: summary.fallback_to_cache
-          });
-          
-          // Show user-friendly message about optimization
-          if (summary.optimized_api_usage) {
-            console.log(`✅ API optimization: Used cached data instead of making unnecessary Instagram API calls`);
-          } else if (summary.rate_limited) {
-            console.log(`⚠️ Rate limited: Used cached data (${summary.cached_posts_available} posts available)`);
-          }
-        }
-        
-        if (data.note || data.warning) {
-          console.log(`💡 Backend note: ${data.note || data.warning}`);
         }
         
         await storeInstagramAnalysis({

--- a/src/app/dashboard/ai-insights/_components/hooks/useYouTubeInsights.ts
+++ b/src/app/dashboard/ai-insights/_components/hooks/useYouTubeInsights.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect } from 'react';
+import { useState, useCallback, useEffect, useMemo } from 'react';
 import { useQuery, useMutation } from "convex/react";
 import { api } from "@/convex/_generated/api";
 import { getApiKey } from '@/app/lib/api-helpers';
@@ -17,29 +17,27 @@ export function useYouTubeInsights(userId?: string): BatchAnalysisHookReturn {
     userId ? { userId } : "skip"
   );
 
+  // Memoize the channelId to avoid unnecessary re-renders
+  const channelId = useMemo(
+    () => youtubeChannel?.id,
+    [youtubeChannel]
+  );
+
   // Fetch YouTube batch analysis insights (will be migrated to universal format)
   const youtubeInsights = useQuery(
     api.youtubeQueries.getYoutubeBatchAnalysis,
-    userId && youtubeChannel?.id ? { 
+    userId && channelId ? { 
       userId, 
-      channelId: youtubeChannel.id 
+      channelId
     } : "skip"
   );
 
   // Store YouTube batch analysis mutation
   const storeYoutubeBatchAnalysis = useMutation(api.youtubeMutations.storeYoutubeBatchAnalysis);
 
-  // Extract data - handle both old and new formats during transition
-  console.log('[useYouTubeInsights] Raw Convex data:', youtubeInsights);
-  console.log('[useYouTubeInsights] youtubeInsights?.insights:', youtubeInsights?.insights);
-  console.log('[useYouTubeInsights] Type of youtubeInsights?.insights:', typeof youtubeInsights?.insights);
-  console.log('[useYouTubeInsights] Is array?', Array.isArray(youtubeInsights?.insights));
-  
   // Check if insights is the universal format object (with insights, metadata, status)
   const rawInsights = youtubeInsights?.insights;
   const isUniversalFormat = rawInsights && typeof rawInsights === 'object' && 'insights' in rawInsights;
-  
-  console.log('[useYouTubeInsights] Is universal format?', isUniversalFormat);
   
   const insightsList: InsightCard[] = isUniversalFormat 
     ? (rawInsights as any).insights || []
@@ -51,10 +49,6 @@ export function useYouTubeInsights(userId?: string): BatchAnalysisHookReturn {
     ? (rawInsights as any).status || null
     : youtubeInsights?.status || null;
     
-  console.log('[useYouTubeInsights] Extracted insightsList:', insightsList);
-  console.log('[useYouTubeInsights] Extracted metadata:', metadata);
-  console.log('[useYouTubeInsights] Extracted status:', status);
-
   // Only show as running if we're actively refreshing AND status is processing/enqueued
   // Don't auto-show loading for old stuck statuses
   // Check both root-level status (updated by mutations) and nested status (from insights)
@@ -72,21 +66,6 @@ export function useYouTubeInsights(userId?: string): BatchAnalysisHookReturn {
   // When user clicks refresh, show refreshing state immediately, even if database hasn't updated yet
   // Once database status updates to processing/enqueued, continue showing refreshing state
   const isActuallyRunning = isRefreshing || databaseStatus === 'processing' || databaseStatus === 'enqueued' || databaseStatus === 'running';
-  
-  console.log('[useYouTubeInsights] Refresh state debug:', {
-    localIsRefreshing: isRefreshing,
-    rootStatus,
-    nestedStatus,
-    databaseStatus,
-    isActuallyRunning,
-    status: status,
-    rootStatusObject: youtubeInsights?.status,
-    currentProgress,
-    rootProgress: youtubeInsights?.status?.progress,
-    nestedProgress: status?.progress,
-    hasChannel: !!youtubeChannel?.id,
-    hasInsights: !!insightsList?.length
-  });
 
   // Check if there's an error in the batch analysis
   const batchError = status?.error;
@@ -103,11 +82,9 @@ export function useYouTubeInsights(userId?: string): BatchAnalysisHookReturn {
     if (isRefreshing && databaseStatus) {
       if (databaseStatus === 'completed' || databaseStatus === 'failed') {
         // Task definitively finished - clear local state
-        console.log('[useYouTubeInsights] Task completed/failed, clearing local refresh state');
         setIsRefreshing(false);
       } else if (databaseStatus === 'processing' || databaseStatus === 'enqueued' || databaseStatus === 'running') {
         // Database caught up with our refresh request - database now drives the state
-        console.log('[useYouTubeInsights] Database status updated to active, local state can continue');
       }
     }
   }, [isRefreshing, databaseStatus]);
@@ -120,22 +97,9 @@ export function useYouTubeInsights(userId?: string): BatchAnalysisHookReturn {
 
     // Prevent multiple concurrent refresh attempts
     if (isRefreshing || databaseStatus === 'processing' || databaseStatus === 'enqueued' || databaseStatus === 'running') {
-      console.log('[useYouTubeInsights] Refresh already in progress, ignoring click', {
-        isRefreshing,
-        databaseStatus,
-        currentTime: new Date().toISOString()
-      });
       return;
     }
 
-    console.log('[useYouTubeInsights] Starting refresh...', {
-      userId,
-      hasChannel: !!youtubeChannel?.id,
-      postLimit,
-      currentTime: new Date().toISOString()
-    });
-
-    // Set local refreshing state
     setIsRefreshing(true);
     setError(null);
     
@@ -172,9 +136,6 @@ export function useYouTubeInsights(userId?: string): BatchAnalysisHookReturn {
       if (data.status === 'enqueued') {
         // YouTube analysis is now async - the status is tracked in the database
         // The results will be automatically available in the query once completed
-        console.log(`✅ YouTube analysis enqueued with task ID: ${data.task_id}`);
-        console.log('[useYouTubeInsights] Task enqueued, keeping local refresh state until database updates');
-        // Keep refreshing state until task completes - database will update via real-time subscription
       } else if (data.status === 'success') {
         // Handle legacy synchronous response (if any)
         await storeYoutubeBatchAnalysis({

--- a/src/app/dashboard/content-analytics/hooks/useInstagramAnalytics.ts
+++ b/src/app/dashboard/content-analytics/hooks/useInstagramAnalytics.ts
@@ -49,7 +49,6 @@ const loadCachedData = (userId: string, instagramAccountId: string): CachedData 
   // Check memory cache first
   const memoryData = memoryCache.get(cacheKey);
   if (memoryData && Date.now() - memoryData.timestamp < CACHE_DURATION) {
-    console.log('📱 Instagram: Using memory cache (hour 0-59)');
     return memoryData;
   }
   
@@ -59,16 +58,12 @@ const loadCachedData = (userId: string, instagramAccountId: string): CachedData 
     if (cached) {
       const parsedCache: CachedData = JSON.parse(cached);
       if (Date.now() - parsedCache.timestamp < CACHE_DURATION) {
-        console.log('📱 Instagram: Using localStorage cache (hour 0-59)');
         // Restore to memory cache
         memoryCache.set(cacheKey, parsedCache);
         return parsedCache;
-      } else {
-        console.log('📱 Instagram: Cache expired (hour 61+) - will fetch fresh data');
       }
     }
   } catch (error) {
-    console.warn('Failed to load cached Instagram data:', error);
   }
   
   return null;
@@ -90,9 +85,7 @@ const saveCachedData = (userId: string, instagramAccountId: string, data: any) =
   // Save to localStorage
   try {
     localStorage.setItem(cacheKey, JSON.stringify(cachedData));
-    console.log('📱 Instagram: Cached fresh data for next 60 minutes');
   } catch (error) {
-    console.warn('Failed to save Instagram data to localStorage:', error);
   }
 };
 
@@ -139,19 +132,16 @@ export function useInstagramAnalytics(userId?: string) {
     
     // If no cache exists, ALWAYS fetch (first visit)
     if (!cached) {
-      console.log('📱 Instagram: No cache found - WILL FETCH from Convex');
       return true;
     }
     
     // If cache exists but is expired, fetch
     const isCacheExpired = (Date.now() - cached.timestamp) >= CACHE_DURATION;
     if (isCacheExpired) {
-      console.log('📱 Instagram: Cache expired - WILL FETCH from Convex');
       return true;
     }
     
     // Cache is valid, don't fetch
-    console.log('📱 Instagram: Valid cache found - SKIP Convex fetch');
     return false;
   }, [userId, instagramAccountId]);
 
@@ -166,19 +156,6 @@ export function useInstagramAnalytics(userId?: string) {
 
   // Map Instagram items with caching - UPDATED for new schema
   const mappedInstagramItems = useMemo(() => {
-    console.log('🔄 Instagram: Mapping posts data:', {
-      hasPosts: !!instagramPosts,
-      postsType: typeof instagramPosts,
-      postsLength: Array.isArray(instagramPosts) ? instagramPosts.length : 'not array',
-      samplePost: Array.isArray(instagramPosts) && instagramPosts.length > 0 ? {
-        id: instagramPosts[0].postId,
-        hasInsights: !!instagramPosts[0].data?.insights,
-        insightsKeys: instagramPosts[0].data?.insights ? Object.keys(instagramPosts[0].data.insights) : null,
-        hasComments: !!instagramPosts[0].data?.comments,
-        commentsLength: instagramPosts[0].data?.comments?.length || 0
-      } : null
-    });
-    
     if (Array.isArray(instagramPosts)) {
       return instagramPosts.map((post: any): InstagramContentItem => {
         let mediaUrl = post.data.media_url;
@@ -255,16 +232,6 @@ export function useInstagramAnalytics(userId?: string) {
     if (userId && instagramAccountId) {
       const cached = loadCachedData(userId, instagramAccountId);
       if (cached) {
-        console.log('📱 Instagram: Loading cached data on mount');
-        console.log('🔍 Instagram: Cached data content:', cached.data);
-        console.log('🔍 Instagram: Cached data structure:', {
-          hasData: !!cached.data,
-          dataType: typeof cached.data,
-          dataKeys: cached.data ? Object.keys(cached.data) : [],
-          hasLastPost: cached.data?.last_post,
-          hasPostingFreq: cached.data?.posting_frequency,
-          hasMediaDist: cached.data?.media_distribution
-        });
         setAnalysis(cached.data);
         setLastFetchTime(cached.timestamp);
         
@@ -273,7 +240,6 @@ export function useInstagramAnalytics(userId?: string) {
         if (dataAge < CACHE_DURATION) {
           // Hour 0-59: Instant display with cached data, NO loading
           setLoading(false);
-          console.log(`📱 Instagram: Cache valid for ${Math.round((CACHE_DURATION - dataAge) / 60000)} more minutes`);
         } else {
           // Hour 61+: Cache expired, keep loading true and will fetch fresh data
           console.log('📱 Instagram: Cache expired, will fetch fresh data');
@@ -290,14 +256,11 @@ export function useInstagramAnalytics(userId?: string) {
   // FIXED: Process Convex tracker analysis when it arrives
   useEffect(() => {
     if (trackerAnalysis !== undefined && userId && instagramAccountId) {
-      console.log('📊 Instagram: Processing Convex tracker analysis:', trackerAnalysis);
-      
       if (trackerAnalysis && Object.keys(trackerAnalysis).length > 0) {
         // Extract the content from the tracker analysis if it's nested
         let analysisToSet = trackerAnalysis;
         if (trackerAnalysis.content && !trackerAnalysis.last_post) {
           analysisToSet = trackerAnalysis.content;
-          console.log('🔧 Instagram: Extracted content from nested structure:', analysisToSet);
         }
         
         // Check if we have valid analysis data
@@ -308,16 +271,11 @@ export function useInstagramAnalytics(userId?: string) {
         );
 
         if (hasValidData) {
-          console.log('✅ Instagram: Using fresh Convex tracker analysis data');
           setAnalysis(analysisToSet);
           setLastFetchTime(Date.now());
           saveCachedData(userId, instagramAccountId, analysisToSet);
           setError(null);
-        } else {
-          console.log('⚠️ Instagram: Tracker analysis exists but has no valid data');
         }
-      } else {
-        console.log('⚠️ Instagram: No tracker analysis found in Convex');
       }
       
       // Always set loading to false when trackerAnalysis query completes
@@ -353,7 +311,6 @@ export function useInstagramAnalytics(userId?: string) {
       }
 
       const data = await response.json();
-      console.log('🔍 Instagram: Backend API Response:', data);
       
       // Process response data
       let analysisToSet = null;
@@ -361,18 +318,14 @@ export function useInstagramAnalytics(userId?: string) {
       if (data?.status === 'success' && data?.data) {
         if (data.data.content && !data.data.last_post) {
           analysisToSet = data.data.content;
-          console.log('✅ Instagram: Using nested content from API response:', analysisToSet);
         } else {
           analysisToSet = data.data;
-          console.log('✅ Instagram: Using data from API response:', analysisToSet);
         }
       } else if (data?.analysis) {
         if (data.analysis.content) {
           analysisToSet = data.analysis.content;
-          console.log('✅ Instagram: Using analysis.content:', analysisToSet);
         } else {
           analysisToSet = data.analysis;
-          console.log('✅ Instagram: Using direct analysis:', analysisToSet);
         }
       }
       
@@ -383,7 +336,6 @@ export function useInstagramAnalytics(userId?: string) {
         setError(null);
         setRefreshSuccess(true);
         setTimeout(() => setRefreshSuccess(false), 3000);
-        console.log('✅ Instagram: Successfully cached fresh data from backend API');
         
         // Force refetch of posts by updating the refresh timestamp
         // This will trigger getAllInstagramPosts to refetch with new insights and comments
@@ -409,10 +361,6 @@ export function useInstagramAnalytics(userId?: string) {
   useEffect(() => {
     // Only reset if userId actually changed (not just on mount or re-renders)
     if (prevUserIdRef.current !== userId && prevUserIdRef.current !== undefined) {
-      console.log('🔄 Instagram: Resetting analysis due to userId change:', { 
-        prevUserId: prevUserIdRef.current, 
-        newUserId: userId 
-      });
       setAnalysis(null);
       setError(null);
       setLastFetchTime(null);

--- a/src/app/dashboard/content-analytics/hooks/useYouTubeAnalytics.ts
+++ b/src/app/dashboard/content-analytics/hooks/useYouTubeAnalytics.ts
@@ -42,7 +42,6 @@ export function useYouTubeAnalytics(userId?: string) {
         
         // --- Always use canonical statistics field ---
         const stats = video.statistics || {};
-        console.log('DEBUG: videoId', videoId, 'canonical statistics', stats, 'raw video:', video);
         const views = Number(stats.views ?? 0);
         const likes = Number(stats.likes ?? 0);
         const dislikes = Number(stats.dislikes ?? 0);


### PR DESCRIPTION
- Added useMemo to memoize account IDs in useGmailInsights, useInstagramInsights, and useYouTubeInsights to prevent unnecessary re-renders.
- Updated query parameters to use memoized account IDs for fetching insights.
- Removed extensive console logging to clean up the code and improve readability.
- Enhanced overall performance by reducing redundant computations in the hooks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved performance and stability in insights hooks for Gmail, Instagram, and YouTube by memoizing account/channel IDs to reduce unnecessary re-renders.
  * Cleaned up code by removing all debug and console logging statements from insights and analytics hooks for Gmail, Instagram, and YouTube.

* **Style**
  * Enhanced code readability by eliminating verbose runtime logs. 

No changes to user-facing functionality or exported interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->