### PR TITLE
style: Update YouTubeBrandIcon sizes in ContentHubInsights and YouTubePlatformCard

### DIFF
--- a/src/app/dashboard/_components/content-hub/ContentHubInsights.tsx
+++ b/src/app/dashboard/_components/content-hub/ContentHubInsights.tsx
@@ -98,7 +98,7 @@ export function ContentHubInsights({ userId, forceExpand }: ContentHubInsightsPr
             </p>
             <div className="flex justify-center gap-4 text-xs text-gray-500">
               <div className={`flex items-center gap-1 ${connectedPlatforms.includes('youtube') ? 'text-gray-900 dark:text-gray-100' : ''}`}>
-                <YouTubeBrandIcon href="https://youtube.com/" className="w-4 h-4" />
+                <YouTubeBrandIcon href="https://youtube.com/" className="w-5 h-5" />
                 YouTube {connectedPlatforms.includes('youtube') ? '✓' : ''}
               </div>
               <div className={`flex items-center gap-1 ${connectedPlatforms.includes('instagram') ? 'text-gray-900 dark:text-gray-100' : ''}`}>
@@ -274,7 +274,7 @@ export function ContentHubInsights({ userId, forceExpand }: ContentHubInsightsPr
             {/* YouTube Section */}
             <PlatformInsightCard
               platform="YouTube"
-              icon={<YouTubeBrandIcon href="https://youtube.com/" className="w-4 h-4" />}
+              icon={<YouTubeBrandIcon href="https://youtube.com/" className="w-8 h-8" />}
               hook={insight.youtube_hook}
               format={insight.youtube_format}
               cta={insight.youtube_cta}

--- a/src/app/settings/tabs/platform-connect/YouTubePlatformCard.tsx
+++ b/src/app/settings/tabs/platform-connect/YouTubePlatformCard.tsx
@@ -62,8 +62,8 @@ export function YouTubePlatformCard({
         </div>
       )}
       <div className="flex items-center gap-3 mb-2">
-        <div className="w-12 h-12 rounded-lg bg-red-600 flex items-center justify-center">
-          <YouTubeBrandIcon href="https://youtube.com/" className="w-6 h-6 text-white" />
+        <div className="w-12 h-12 rounded-lg flex items-center justify-center">
+          <YouTubeBrandIcon href="https://youtube.com/" className="w-8 h-8 text-white" />
         </div>
         <div>
           <h3 className="text-lg font-semibold">YouTube</h3>


### PR DESCRIPTION
- Increased the size of YouTubeBrandIcon from w-4 h-4 to w-5 h-5 in ContentHubInsights for better visibility.
- Adjusted YouTubeBrandIcon size from w-6 h-6 to w-8 h-8 in YouTubePlatformCard to maintain consistency across components.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Increased the size of the YouTube icon in various sections for improved visibility.
  * Updated the YouTube platform card by removing the red background behind the icon and enlarging the icon for a cleaner appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->