### PR TITLE
feat: Implement persona generation eligibility checks and cooldown en…

### DIFF
--- a/convex/personas.ts
+++ b/convex/personas.ts
@@ -4,6 +4,78 @@ import { Id } from "./_generated/dataModel";
 
 type ExperienceLevel = "Beginner" | "Intermediate" | "Experienced" | "Professional";
 
+// Constants
+const TWO_WEEKS_MS = 14 * 24 * 60 * 60 * 1000; // 14 days in milliseconds
+
+// Query to check if user can generate a new persona (cooldown check)
+export const checkPersonaGenerationEligibility = query({
+  args: {
+    userId: v.string(),
+  },
+  returns: v.object({
+    canGenerate: v.boolean(),
+    nextAvailable: v.optional(v.number()),
+    lastGenerated: v.optional(v.number()),
+    daysRemaining: v.optional(v.number()),
+    mustUpdate: v.boolean(),
+  }),
+  handler: async (ctx, args) => {
+    try {
+      const { userId } = args;
+      
+      // Get the most recent persona for this user
+      const mostRecentPersona = await ctx.db
+        .query("personas")
+        .withIndex("by_userId", (q) => q.eq("userId", userId))
+        .order("desc")
+        .first();
+
+      if (!mostRecentPersona) {
+        // No previous persona, user can generate
+        return {
+          canGenerate: true,
+          mustUpdate: false,
+        };
+      }
+
+      const now = Date.now();
+      // Use _creationTime for cooldown logic (Convex system field)
+      const lastGenerated = mostRecentPersona._creationTime;
+      const timeSinceLastGeneration = now - lastGenerated;
+      const mustUpdate = timeSinceLastGeneration >= TWO_WEEKS_MS;
+      console.log('[CHECK ELIGIBILITY] now:', now, 'lastGenerated:', lastGenerated, 'timeSinceLastGeneration:', timeSinceLastGeneration, 'TWO_WEEKS_MS:', TWO_WEEKS_MS);
+      if (timeSinceLastGeneration >= TWO_WEEKS_MS) {
+        // Cooldown period has passed
+        console.log('[CHECK ELIGIBILITY] Returning canGenerate: true', { canGenerate: true, lastGenerated, mustUpdate });
+        return {
+          canGenerate: true,
+          lastGenerated,
+          mustUpdate,
+        };
+      } else {
+        // Still in cooldown period
+        const nextAvailable = lastGenerated + TWO_WEEKS_MS;
+        const daysRemaining = Math.ceil((nextAvailable - now) / (24 * 60 * 60 * 1000));
+        console.log('[CHECK ELIGIBILITY] Returning canGenerate: false', { canGenerate: false, nextAvailable, lastGenerated, daysRemaining, mustUpdate });
+        return {
+          canGenerate: false,
+          nextAvailable,
+          lastGenerated,
+          daysRemaining,
+          mustUpdate,
+        };
+      }
+    } catch (error) {
+      console.error("Error checking persona generation eligibility:", error);
+      // Default to allowing generation on error
+      return {
+        canGenerate: true,
+        mustUpdate: false,
+      };
+    }
+  },
+});
+
 // Query to get the active persona for a user
 export const getPersona = query({
   args: {
@@ -116,7 +188,7 @@ export const getPersonaData = query({
   },
 });
 
-// Mutation to create a new persona
+// Mutation to create a new persona (with two-week cooldown enforcement)
 export const createPersona = mutation({
   args: {
     userId: v.string(),
@@ -138,9 +210,48 @@ export const createPersona = mutation({
     style_descriptors: v.array(v.string()),
     audience_type: v.string(),
     engagement_style: v.array(v.string()),
+    bypassCooldown: v.optional(v.boolean()), // Admin override
   },
+  returns: v.union(
+    v.object({
+      success: v.literal(true),
+      personaId: v.id("personas"),
+    }),
+    v.object({
+      success: v.literal(false),
+      error: v.string(),
+      nextAvailable: v.optional(v.number()),
+      daysRemaining: v.optional(v.number()),
+    })
+  ),
   handler: async (ctx, args) => {
+    const { bypassCooldown, ...personaArgs } = args;
     const timestamp = Date.now();
+    
+    // Check cooldown unless bypassed (for admin operations)
+    if (!bypassCooldown) {
+      const mostRecentPersona = await ctx.db
+        .query("personas")
+        .withIndex("by_userId", (q) => q.eq("userId", args.userId))
+        .order("desc")
+        .first();
+
+      if (mostRecentPersona) {
+        // Use _creationTime for cooldown logic
+        const lastGenerated = mostRecentPersona._creationTime;
+        const timeSinceLastGeneration = timestamp - lastGenerated;
+        if (timeSinceLastGeneration < TWO_WEEKS_MS) {
+          const nextAvailable = lastGenerated + TWO_WEEKS_MS;
+          const daysRemaining = Math.ceil((nextAvailable - timestamp) / (24 * 60 * 60 * 1000));
+          return {
+            success: false as const,
+            error: `Your persona is currently in its growth phase! We'll help you evolve it again in ${daysRemaining} day${daysRemaining !== 1 ? 's' : ''} to track your amazing progress.`,
+            nextAvailable,
+            daysRemaining,
+          };
+        }
+      }
+    }
     
     // Deactivate all previous personas for this user
     const allPersonas = await ctx.db
@@ -156,12 +267,17 @@ export const createPersona = mutation({
     }
 
     // Create new persona with all fields
-    return await ctx.db.insert("personas", {
-      ...args,
+    const personaId = await ctx.db.insert("personas", {
+      ...personaArgs,
       isActive: true,
       createdAt: timestamp,
       updatedAt: timestamp,
     });
+
+         return {
+       success: true as const,
+       personaId,
+     };
   },
 });
 

--- a/src/app/dashboard/chat/ChatContainer.tsx
+++ b/src/app/dashboard/chat/ChatContainer.tsx
@@ -169,19 +169,7 @@ const ChatContainer: React.FC<ChatScreenProps> = ({ chatId, contentContext, askQ
     initSession
   } = useConversation(chatState, authData.user)
 
-  // Initialize welcome message hook
-  const {
-    welcomeStep,
-    setWelcomeStep,
-    handleSuggestionClick: handleWelcomeSuggestionClick
-  } = useWelcomeMessage(
-    true,
-    messages,
-    isLoading,
-    authData.user,
-    setMessages,
-    hasPersona
-  )
+  // Remove welcome message hook for new chat; only show ambient insights when chat is empty
 
   // Notepad functionality
   const {
@@ -306,9 +294,11 @@ const ChatContainer: React.FC<ChatScreenProps> = ({ chatId, contentContext, askQ
     handleSendMessage(action);
   }, [handleSendMessage]);
 
+  // Directly send suggestion, no welcome flow
   const handleSuggestionClick = useCallback((suggestion: any, onSendMessage: (msg: string) => void) => {
-    handleWelcomeSuggestionClick(suggestion, handleSendMessage);
-  }, [handleWelcomeSuggestionClick, handleSendMessage]);
+    const message = typeof suggestion === 'string' ? suggestion : suggestion.description;
+    onSendMessage(message);
+  }, [handleSendMessage]);
 
   const handleInsightClick = useCallback((action: string, insight: any) => {
     handleSendMessageWithUpdateCheck(action);

--- a/src/app/dashboard/chat/components/PersonaTip.tsx
+++ b/src/app/dashboard/chat/components/PersonaTip.tsx
@@ -1,5 +1,8 @@
-import React, { useState } from 'react';
-import { MessageCircle, Info, X } from 'lucide-react';
+import React, { useState, useEffect } from 'react';
+import { MessageCircle, Info, X, Clock } from 'lucide-react';
+import { useQuery } from "convex/react";
+import { api } from "../../../../../convex/_generated/api";
+import { getCurrentUserId } from '@/app/lib/api-helpers';
 
 // Add a simple sparkle SVG component
 const Sparkle = () => (
@@ -25,27 +28,91 @@ interface PersonaTipProps {
 }
 
 export const PersonaTip: React.FC<PersonaTipProps> = ({ onTipClick }) => {
+  const [userId, setUserId] = useState<string | null>(null);
+
+  // Get user ID using Firebase auth pattern
+  useEffect(() => {
+    const fetchUserId = () => {
+      const currentUserId = getCurrentUserId();
+      setUserId(currentUserId);
+    };
+    
+    fetchUserId();
+    
+    // Set up an interval to check for user ID changes
+    const interval = setInterval(fetchUserId, 1000);
+    return () => clearInterval(interval);
+  }, []);
   const [isExpanded, setIsExpanded] = useState(false);
+  const [showFloatingTip, setShowFloatingTip] = useState(() => {
+    // Only show if user hasn't clicked before
+    return typeof window !== 'undefined' && localStorage.getItem('personaFloatingTipDismissed') !== 'true';
+  });
+
+  // Check persona generation eligibility
+  const eligibility = useQuery(
+    api.personas.checkPersonaGenerationEligibility,
+    userId ? { userId } : "skip"
+  );
 
   const handleClick = () => {
-    localStorage.setItem('personaTipClicked', 'true');
-    onTipClick('hey content write my persona');
-    setIsExpanded(false);
+    if (eligibility?.canGenerate) {
+      localStorage.setItem('personaTipClicked', 'true');
+      setShowFloatingTip(false);
+      onTipClick('hey content write my persona');
+      setIsExpanded(false);
+    }
   };
 
   const toggleExpand = () => {
     setIsExpanded(!isExpanded);
+    setShowFloatingTip(false);
+    localStorage.setItem('personaFloatingTipDismissed', 'true');
+  };
+
+  const handleFloatingTipClose = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    setShowFloatingTip(false);
+    localStorage.setItem('personaFloatingTipDismissed', 'true');
   };
 
   return (
-    <div className="fixed right-4 bottom-24 z-10">
+    <div className="fixed right-4 bottom-24 z-10 flex flex-col items-end">
+      {/* Floating friendly tip */}
+      {showFloatingTip && !isExpanded && (
+        <div className="mb-2 relative animate-in fade-in-20 slide-in-from-bottom-2 duration-300">
+          <div className="bg-yellow-50 border border-yellow-200 rounded-lg shadow-lg px-4 py-3 max-w-xs w-72 flex items-start gap-2 relative">
+            <span className="text-lg">{eligibility?.canGenerate ? '✨' : '🌱'}</span>
+            <div className="flex-1">
+              <span className="block text-sm font-medium text-yellow-900">
+{eligibility?.canGenerate ? (
+                  'Ready to shine? '
+                ) : (
+                  'Your persona is growing! '
+                )}<span className="font-semibold">{eligibility?.canGenerate ? 'Tap below when you feel inspired to create your persona!' : 'We\'ll help you evolve it soon!'}</span>
+              </span>
+              <span className="block text-xs text-yellow-700 mt-1">
+                Your creative journey starts with a single tap. No rush—when you’re ready, we’ll help you craft your unique story!
+              </span>
+            </div>
+            <button
+              onClick={handleFloatingTipClose}
+              className="ml-2 mt-0.5 text-yellow-400 hover:text-yellow-600 focus:outline-none"
+              aria-label="Dismiss tip"
+            >
+              <X className="w-4 h-4" />
+            </button>
+          </div>
+        </div>
+      )}
+      {/* PersonaTip main button or expanded card */}
       {isExpanded ? (
         <div className="relative bg-white border border-gray-200 rounded-lg shadow-lg p-4 max-w-xs w-64 animate-in fade-in-20 slide-in-from-bottom-4 duration-300">
           {/* Sparkle in the corner */}
           <Sparkle />
           <div className="flex justify-between items-start mb-2">
             <h4 className="text-sm font-semibold text-gray-800">
-              Create Your Persona
+              {eligibility?.canGenerate ? 'Create Your Persona' : 'Persona Growth Phase'}
             </h4>
             <button
               onClick={toggleExpand}
@@ -55,19 +122,42 @@ export const PersonaTip: React.FC<PersonaTipProps> = ({ onTipClick }) => {
               <X className="w-4 h-4" />
             </button>
           </div>
-          <p className="text-sm text-gray-600 mb-3">
-            Ready to create your personalized content persona? Just say the magic words!
-          </p>
-          <p className="text-xs text-gray-500 mb-4">
-            (For best results, please disable smart search)
-          </p>
-          <button
-            onClick={handleClick}
-            className="w-full inline-flex items-center justify-center px-3 py-2 bg-gray-900 text-white text-sm font-medium rounded-md hover:bg-gray-700 transition-colors duration-200"
-          >
-            <MessageCircle className="w-4 h-4 mr-2" />
-            <span>Create my persona</span>
-          </button>
+          {eligibility?.canGenerate ? (
+            <>
+              <p className="text-sm text-gray-600 mb-3">
+                Ready to create your personalized content persona? Just say the magic words!
+              </p>
+              <p className="text-xs text-gray-500 mb-4">
+                (For best results, please disable smart search)
+              </p>
+              <button
+                onClick={handleClick}
+                className="w-full inline-flex items-center justify-center px-3 py-2 bg-gray-900 text-white text-sm font-medium rounded-md hover:bg-gray-700 transition-colors duration-200"
+              >
+                <MessageCircle className="w-4 h-4 mr-2" />
+                <span>Create my persona</span>
+              </button>
+            </>
+          ) : (
+            <>
+              <p className="text-sm text-gray-600 mb-3">
+                🌱 Your persona is in its growth phase! We help creators evolve their personas every 2 weeks to track progress, capture new goals, and stay aligned with their creative journey.
+              </p>
+              {eligibility?.daysRemaining && (
+                                  <p className="text-xs text-emerald-600 mb-4 flex items-center">
+                    <span className="mr-1">🌟</span>
+                    Your evolution continues in {eligibility.daysRemaining} day{eligibility.daysRemaining !== 1 ? 's' : ''}!
+                  </p>
+              )}
+                              <button
+                  disabled
+                  className="w-full inline-flex items-center justify-center px-3 py-2 bg-emerald-100 text-emerald-700 text-sm font-medium rounded-md cursor-not-allowed"
+                >
+                  <span className="mr-2">🌱</span>
+                  <span>Growing stronger every day</span>
+                </button>
+            </>
+          )}
         </div>
       ) : (
         <button

--- a/src/app/dashboard/self-hub/PersonaTab.tsx
+++ b/src/app/dashboard/self-hub/PersonaTab.tsx
@@ -5,7 +5,11 @@ import { useAuth } from '@/app/context/auth-context';
 import { useRouter } from 'next/navigation';
 import { Skeleton } from '@/components/ui/skeleton';
 import { usePersonaStore } from '@/store/persona-store';
-import { useConvex } from 'convex/react';
+import { useConvex, useQuery } from 'convex/react';
+import { api } from '@/convex/_generated/api';
+import { Button } from '@/components/ui/button';
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from '@/components/ui/dialog';
+import { X } from 'lucide-react';
 
 // Lazy load PersonaUpdateManager to reduce initial bundle size
 const PersonaUpdateManager = React.lazy(() => 
@@ -83,7 +87,9 @@ const PersonaTabSkeleton = React.memo(() => (
 PersonaTabSkeleton.displayName = 'PersonaTabSkeleton';
 
 export const PersonaTab = React.memo(() => {
-  console.log('🎯 [PERSONA TAB] ⚡ LAZY Component rendering started at:', new Date().toISOString());
+  // Always declare hooks at the very top before any conditional return
+  const [modalOpen, setModalOpen] = React.useState(true);
+  console.log('[PERSONA TAB] Component rendering started at:', new Date().toISOString());
   const renderStartTime = performance.now();
   
   const { firebaseUser, authLoading } = useAuth();
@@ -100,59 +106,56 @@ export const PersonaTab = React.memo(() => {
   const refreshPersonaData = usePersonaStore(state => state.refreshPersonaData);
   const lastFetchedUserId = usePersonaStore(state => state.lastFetchedUserId);
 
-  console.log('🎯 [PERSONA TAB] ⚡ LAZY Auth state:', {
-    authLoading,
-    hasFirebaseUser: !!firebaseUser,
-    firebaseUserUid: firebaseUser?.uid
-  });
-
-  console.log('🎯 [PERSONA TAB] ⚡ LAZY Persona store state:', {
-    isPersonaLoading,
-    isPersonaInitialized,
-    hasCurrentPersona: !!currentPersona,
-    allPersonasCount: allPersonas.length,
-    isCacheValid: isCacheValid(),
-    lastFetchedUserId,
-    timestamp: new Date().toISOString()
-  });
+  // Check persona generation eligibility for structured growth messaging
+  // Personas can only be generated once every two weeks to:
+  // 1. Track meaningful progress and goal evolution
+  // 2. Maintain consistency in creator journey tracking
+  // 3. Prevent content strategy confusion from too-frequent changes
+  // 4. Encourage structured reflection and intentional growth
+  const eligibility = useQuery(
+    api.personas.checkPersonaGenerationEligibility,
+    firebaseUser?.uid ? { userId: firebaseUser.uid } : "skip"
+  );
 
   // Initialize persona data ONLY when PersonaTab is rendered and we have a user
   useEffect(() => {
     const effectStartTime = performance.now();
-    console.log('🎯 [PERSONA TAB] ⚡ LAZY useEffect triggered for persona initialization');
+    console.log('[PERSONA TAB] useEffect triggered for persona initialization');
     
     if (firebaseUser?.uid) {
       // Always ensure we have fresh data for this user
       if (!isPersonaInitialized || lastFetchedUserId !== firebaseUser.uid || !currentPersona) {
-        console.log('🎯 [PERSONA TAB] ⚡ LAZY Initializing persona data - fresh fetch needed!');
+        console.log('[PERSONA TAB] Initializing persona data - fresh fetch needed');
         initializePersonaData(firebaseUser.uid, convex).then(() => {
           const effectEndTime = performance.now();
-          console.log('🎯 [PERSONA TAB] ⚡ LAZY Persona initialization completed in:', Math.round(effectEndTime - effectStartTime), 'ms');
+          console.log('[PERSONA TAB] Persona initialization completed in:', Math.round(effectEndTime - effectStartTime), 'ms');
         }).catch((error) => {
           const effectErrorTime = performance.now();
-          console.error('❌ [PERSONA TAB] LAZY Persona initialization failed in:', Math.round(effectErrorTime - effectStartTime), 'ms, error:', error);
+          console.error('[PERSONA TAB] Persona initialization failed in:', Math.round(effectErrorTime - effectStartTime), 'ms, error:', error);
         });
       } else if (!isCacheValid()) {
         // If cache is stale, refresh the data
-        console.log('🎯 [PERSONA TAB] ⚡ LAZY Cache is stale - refreshing persona data');
+        console.log('[PERSONA TAB] Cache is stale - refreshing persona data');
         refreshPersonaData(firebaseUser.uid, convex);
       } else {
-        console.log('🎯 [PERSONA TAB] ⚡ LAZY Using valid cached data');
+        console.log('[PERSONA TAB] Using valid cached data');
       }
     }
   }, [firebaseUser?.uid, isPersonaInitialized, lastFetchedUserId, currentPersona, isCacheValid, initializePersonaData, refreshPersonaData, convex]);
 
-  // Memoize the new persona handler
+  // Memoize the new persona handler with eligibility check
   const handleNewPersona = React.useCallback(() => {
-    console.log('🎯 [PERSONA TAB] New persona button clicked');
-    router.push('/dashboard/chat?ask=' + encodeURIComponent('hey content update persona'));
-  }, [router]);
+    if (eligibility?.canGenerate) {
+      console.log('[PERSONA TAB] New persona button clicked');
+      router.push('/dashboard/chat?ask=' + encodeURIComponent('hey content update persona'));
+    }
+  }, [router, eligibility?.canGenerate]);
 
   // Simplified loading state - prioritize showing persona when available
   const loadingState = useMemo(() => {
     // Always show persona if we have it, even if loading in background
     if (currentPersona) {
-      console.log('🎯 [PERSONA TAB] ⚡ LAZY - showing current persona!');
+      console.log('[PERSONA TAB] Showing current persona');
       return 'ready';
     }
     
@@ -171,19 +174,46 @@ export const PersonaTab = React.memo(() => {
     return 'initializing';
   }, [authLoading, firebaseUser, isPersonaLoading, isPersonaInitialized, currentPersona]);
   
-  console.log('🎯 [PERSONA TAB] ⚡ LAZY Loading state:', loadingState, {
+  React.useEffect(() => {
+    if (eligibility?.mustUpdate) setModalOpen(true);
+    else setModalOpen(false);
+  }, [eligibility?.mustUpdate]);
+
+  // ALL HOOKS ARE NOW DECLARED - CONDITIONAL RENDERING BELOW
+
+  console.log('[PERSONA TAB] Auth state:', {
+    authLoading,
+    hasFirebaseUser: !!firebaseUser,
+    firebaseUserUid: firebaseUser?.uid
+  });
+
+  console.log('[PERSONA TAB] Persona store state:', {
+    isPersonaLoading,
+    isPersonaInitialized,
+    hasCurrentPersona: !!currentPersona,
+    allPersonasCount: allPersonas.length,
+    isCacheValid: isCacheValid(),
+    lastFetchedUserId,
+    eligibilityCanGenerate: eligibility?.canGenerate,
+    daysRemaining: eligibility?.daysRemaining,
+    timestamp: new Date().toISOString()
+  });
+
+  console.log('[PERSONA TAB] Loading state:', loadingState, {
     authLoading,
     isPersonaLoading,
     isPersonaInitialized,
     hasFirebaseUser: !!firebaseUser,
     hasCurrentPersona: !!currentPersona,
-    hasCachedData: allPersonas.length > 0
+    hasCachedData: allPersonas.length > 0,
+    canGeneratePersona: eligibility?.canGenerate,
+    daysUntilNextGeneration: eligibility?.daysRemaining
   });
 
   // Show appropriate loading UI based on state
   if (loadingState === 'initializing' || loadingState === 'loading') {
     const skeletonStartTime = performance.now();
-    console.log('🎯 [PERSONA TAB] Showing loading state at:', new Date().toISOString(), 'render time so far:', Math.round(skeletonStartTime - renderStartTime), 'ms');
+    console.log('[PERSONA TAB] Showing loading state at:', new Date().toISOString(), 'render time so far:', Math.round(skeletonStartTime - renderStartTime), 'ms');
     
     return (
       <div className="flex justify-center items-start min-h-[400px] px-4 py-8">
@@ -194,12 +224,82 @@ export const PersonaTab = React.memo(() => {
 
   // Always render PersonaUpdateManager when ready
   const finalRenderTime = performance.now();
-  console.log('🎯 [PERSONA TAB] ⚡ LAZY Rendering PersonaUpdateManager at:', new Date().toISOString(), 'total render time:', Math.round(finalRenderTime - renderStartTime), 'ms');
+  console.log('[PERSONA TAB] Rendering PersonaUpdateManager at:', new Date().toISOString(), 'total render time:', Math.round(finalRenderTime - renderStartTime), 'ms');
+
+  // Debug logs for eligibility and currentPersona
+  console.log('[PERSONA TAB] eligibility:', eligibility);
+  console.log('[PERSONA TAB] currentPersona:', currentPersona);
+
+  if (eligibility?.mustUpdate) {
+    return (
+      <>
+        <Dialog open={modalOpen} onOpenChange={setModalOpen}>
+          <DialogContent className="fixed top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 max-w-md w-full mx-4 z-50">
+            <DialogHeader>
+              <DialogTitle>Time to Refresh Your Persona!</DialogTitle>
+              <DialogDescription>
+                It's been 14 days since your last persona update. To keep your creative journey on track and your insights fresh, please update your persona before continuing.
+              </DialogDescription>
+            </DialogHeader>
+            <div className="flex flex-col gap-4 mt-4">
+              <Button
+                onClick={handleNewPersona}
+                variant="outline"
+                size="sm"
+                className="text-purple-500 border-purple-500 hover:bg-purple-50 dark:text-accent dark:border-accent dark:hover:bg-accent/10 min-h-[44px] w-full sm:w-auto"
+              >
+                Update Persona Now
+              </Button>
+            </div>
+          </DialogContent>
+        </Dialog>
+        {!modalOpen && (
+          <div className="w-full">
+            <Suspense fallback={<PersonaTabSkeleton />}>
+              <PersonaUpdateManager 
+                userId={firebaseUser?.uid} 
+                renderNewPersonaButton={() => (
+                  <Button
+                    onClick={handleNewPersona}
+                    disabled={!eligibility?.canGenerate}
+                    variant="outline"
+                    size="sm"
+                    className="text-purple-500 border-purple-500 hover:bg-purple-50 dark:text-accent dark:border-accent dark:hover:bg-accent/10 min-h-[44px] w-full sm:w-auto"
+                    aria-disabled={!eligibility?.canGenerate}
+                  >
+                    {eligibility?.canGenerate
+                      ? (currentPersona ? 'Update Persona' : 'Create Persona')
+                      : `Update available in ${eligibility?.daysRemaining ?? 'a few'} day${eligibility?.daysRemaining !== 1 ? 's' : ''}`}
+                  </Button>
+                )}
+              />
+            </Suspense>
+          </div>
+        )}
+      </>
+    );
+  }
 
   return (
     <div className="w-full">
       <Suspense fallback={<PersonaTabSkeleton />}>
-        <PersonaUpdateManager userId={firebaseUser?.uid} renderNewPersonaButton={handleNewPersona} />
+        <PersonaUpdateManager 
+          userId={firebaseUser?.uid} 
+          renderNewPersonaButton={() => (
+            <Button
+              onClick={handleNewPersona}
+              disabled={!eligibility?.canGenerate}
+              variant="outline"
+              size="sm"
+              className="text-purple-500 border-purple-500 hover:bg-purple-50 dark:text-accent dark:border-accent dark:hover:bg-accent/10 min-h-[44px] w-full sm:w-auto"
+              aria-disabled={!eligibility?.canGenerate}
+            >
+              {eligibility?.canGenerate
+                ? (currentPersona ? 'Update Persona' : 'Create Persona')
+                : `Update available in ${eligibility?.daysRemaining ?? 'a few'} day${eligibility?.daysRemaining !== 1 ? 's' : ''}`}
+            </Button>
+          )}
+        />
       </Suspense>
     </div>
   );

--- a/src/app/settings/tabs/account/PersonaUpdateManager.tsx
+++ b/src/app/settings/tabs/account/PersonaUpdateManager.tsx
@@ -221,16 +221,7 @@ export const PersonaUpdateManager: React.FC<PersonaUpdateManagerProps> = ({ user
                 Delete
               </Button>
             )}
-            {!isEditMode && renderNewPersonaButton && (
-              <Button 
-                onClick={renderNewPersonaButton} 
-                variant="outline" 
-                className="text-purple-500 border-purple-500 hover:bg-purple-50 dark:text-accent dark:border-accent dark:hover:bg-accent/10 min-h-[44px] w-full sm:w-auto" 
-                size="sm"
-              >
-                New Persona
-              </Button>
-            )}
+            {!isEditMode && renderNewPersonaButton && renderNewPersonaButton()}
           </div>
         </div>
 


### PR DESCRIPTION
This pull request introduces a cooldown mechanism for persona generation, enhances user feedback during the persona lifecycle, and refines the user interface to improve the overall experience. Key changes include adding a two-week cooldown for persona creation, integrating eligibility checks across the app, and updating the UI to reflect the persona's growth phase.

### Persona Generation Cooldown and Eligibility Checks:
* Introduced a two-week cooldown for persona creation using a new constant `TWO_WEEKS_MS` and a `checkPersonaGenerationEligibility` query to determine if users can create a new persona. The query provides cooldown details such as `daysRemaining` and `nextAvailable` timestamps. (`convex/personas.ts`, [convex/personas.tsR7-R78](diffhunk://#diff-d7824058d406c5544691ea0275b0e373f8970c41858b60d85b7402988b7087f7R7-R78))
* Updated the `createPersona` mutation to enforce the cooldown logic, with an optional `bypassCooldown` parameter for admin overrides. It now returns structured responses indicating success or failure, including cooldown details if applicable. (`convex/personas.ts`, [[1]](diffhunk://#diff-d7824058d406c5544691ea0275b0e373f8970c41858b60d85b7402988b7087f7R213-R255) [[2]](diffhunk://#diff-d7824058d406c5544691ea0275b0e373f8970c41858b60d85b7402988b7087f7L159-R280)

### User Interface Updates:
* Enhanced the `PersonaTip` component to display dynamic messages based on persona eligibility. Added a floating tip with contextual guidance and disabled the persona creation button during the cooldown period. (`src/app/dashboard/chat/components/PersonaTip.tsx`, [[1]](diffhunk://#diff-f1273c50845b2ac6f412f2cf9495b4f57ad1e8d35eab94791f5388cda2ca55ebL1-R5) [[2]](diffhunk://#diff-f1273c50845b2ac6f412f2cf9495b4f57ad1e8d35eab94791f5388cda2ca55ebR31-R115) [[3]](diffhunk://#diff-f1273c50845b2ac6f412f2cf9495b4f57ad1e8d35eab94791f5388cda2ca55ebR125-R126) [[4]](diffhunk://#diff-f1273c50845b2ac6f412f2cf9495b4f57ad1e8d35eab94791f5388cda2ca55ebR140-R160)
* Updated the `PersonaTab` to integrate eligibility checks, display structured growth messaging, and conditionally enable persona creation based on cooldown status. (`src/app/dashboard/self-hub/PersonaTab.tsx`, [[1]](diffhunk://#diff-336e384cb2da1d76685ac157cc99a4782ea9776afbb82d3345465b1f39a2142cL8-R12) [[2]](diffhunk://#diff-336e384cb2da1d76685ac157cc99a4782ea9776afbb82d3345465b1f39a2142cL103-R158) [[3]](diffhunk://#diff-336e384cb2da1d76685ac157cc99a4782ea9776afbb82d3345465b1f39a2142cL174-R216)

### Codebase Simplifications:
* Removed the welcome message hook from the `ChatContainer` component to streamline the chat initialization process. (`src/app/dashboard/chat/ChatContainer.tsx`, [[1]](diffhunk://#diff-eda28b05cc40874b622befdf8be6cec623f40b65593a2feb306c117819fd1754L172-R172) [[2]](diffhunk://#diff-eda28b05cc40874b622befdf8be6cec623f40b65593a2feb306c117819fd1754R297-R301)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a 14-day cooldown period for persona creation and updates, with clear eligibility checks and informative UI feedback.
  * Added eligibility-aware tips and modals to guide users through the persona creation lifecycle, including countdowns until the next allowed update.
  * Enhanced persona creation and update buttons to reflect eligibility status and remaining cooldown time.

* **Improvements**
  * Simplified chat suggestion handling for a more streamlined user experience.
  * Improved persona-related UI components for better clarity and persistent tip dismissal.

* **Bug Fixes**
  * Standardized logging and improved state management in persona-related components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->