### PR TITLE
Add optional fields for titleGenerated and typeGenerated in updateNote mutation

### DIFF
--- a/convex/noteMutations.ts
+++ b/convex/noteMutations.ts
@@ -48,6 +48,8 @@ export const updateNote = mutation({
       type: v.optional(noteType),
       tags: v.optional(v.array(v.string())),
       important: v.optional(v.boolean()),
+      titleGenerated: v.optional(v.boolean()),
+      typeGenerated: v.optional(v.boolean()),
     }),
   },
   handler: async (ctx, { noteId, userId, updates }) => {


### PR DESCRIPTION
This pull request adds two new optional boolean fields, `titleGenerated` and `typeGenerated`, to the `updateNote` mutation in `convex/noteMutations.ts`. These fields will allow tracking whether the note's title or type was generated programmatically.

Key change:

* [`convex/noteMutations.ts`](diffhunk://#diff-cfcf030dd182b441cdfc7bf7600848ba967a7271811011f2a5df86d28dbc741bR51-R52): Added `titleGenerated` and `typeGenerated` as optional boolean fields to the `updateNote` mutation schema.