### PR TITLE
Update splitCursor type in Gmail queries to allow null values (#422)

### DIFF
--- a/convex/gmailQueries.ts
+++ b/convex/gmailQueries.ts
@@ -128,7 +128,7 @@ export const getGmailThreadsPaginated = query({
     isDone: v.boolean(),
     continueCursor: v.union(v.string(), v.null()),
     pageStatus: v.optional(v.any()),
-    splitCursor: v.optional(v.string()),
+    splitCursor: v.optional(v.union(v.string(), v.null())),
   }),
   handler: async (ctx, args) => {
     let query = ctx.db
@@ -190,7 +190,7 @@ export const getGmailMessagesPaginated = query({
     isDone: v.boolean(),
     continueCursor: v.union(v.string(), v.null()),
     pageStatus: v.optional(v.any()),
-    splitCursor: v.optional(v.string()),
+    splitCursor: v.optional(v.union(v.string(), v.null())),
   }),
   handler: async (ctx, args) => {
     let query = ctx.db


### PR DESCRIPTION
This pull request includes updates to enhance type validation and add support for image metadata in the `convex` backend queries and mutations. The most important changes involve refining type definitions for cursors in pagination queries and introducing a new schema for handling image metadata in note updates.

### Type validation improvements:

* [`convex/gmailQueries.ts`](diffhunk://#diff-5b347767fc3ff6ab2fc60b307338cf08ea945fdafc23e16d666ecd60677b615eL131-R131): Updated the `splitCursor` field in both `getGmailThreadsPaginated` and `getGmailMessagesPaginated` to accept either a string or `null` for better type safety and flexibility. [[1]](diffhunk://#diff-5b347767fc3ff6ab2fc60b307338cf08ea945fdafc23e16d666ecd60677b615eL131-R131) [[2]](diffhunk://#diff-5b347767fc3ff6ab2fc60b307338cf08ea945fdafc23e16d666ecd60677b615eL193-R193)

### Support for image metadata:

* [`convex/noteMutations.ts`](diffhunk://#diff-cfcf030dd182b441cdfc7bf7600848ba967a7271811011f2a5df86d28dbc741bR53-R64): Added an `images` field to the `updateNote` mutation schema, allowing optional arrays of image metadata objects. Each object includes properties such as `filename`, `mimeType`, `size`, and `url`, among others.