### PR TITLE
Add manual selection functionality for Instagram batch analysis (#491)

### DIFF
--- a/src/app/dashboard/ai-insights/_components/AnalysisDepthPicker.tsx
+++ b/src/app/dashboard/ai-insights/_components/AnalysisDepthPicker.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import React, { useState } from 'react';
-import { RefreshCw, AlertCircle, Settings, Zap, ChevronDown } from 'lucide-react';
+import { RefreshCw, AlertCircle, Settings, Zap, ChevronDown, Grid3X3, Zap as Auto } from 'lucide-react';
 
 type PresetOption = {
   value: number;
@@ -21,6 +21,14 @@ interface AnalysisDepthPickerProps {
   showCustomInput: boolean;
   setShowCustomInput: (show: boolean) => void;
   handleCustomSubmit: () => void;
+  // New props for manual selection
+  selectionMode?: 'auto' | 'manual';
+  onSelectionModeChange?: (mode: 'auto' | 'manual') => void;
+  selectedPostIds?: string[];
+  onSelectedPostsChange?: (postIds: string[]) => void;
+  availablePosts?: any[];
+  showPostSelection?: boolean;
+  onShowPostSelectionChange?: (show: boolean) => void;
 }
 
 export function AnalysisDepthPicker({
@@ -36,6 +44,14 @@ export function AnalysisDepthPicker({
   showCustomInput,
   setShowCustomInput,
   handleCustomSubmit,
+  // New props
+  selectionMode = 'auto',
+  onSelectionModeChange,
+  selectedPostIds = [],
+  onSelectedPostsChange,
+  availablePosts = [],
+  showPostSelection = false,
+  onShowPostSelectionChange,
 }: AnalysisDepthPickerProps) {
   const [isCollapsed, setIsCollapsed] = useState(true);
   const presetOptions: PresetOption[] = [
@@ -44,6 +60,19 @@ export function AnalysisDepthPicker({
     { value: 15, label: '15' },
     { value: 20, label: '20' },
   ];
+
+  const handleSelectionModeChange = (mode: 'auto' | 'manual') => {
+    if (onSelectionModeChange) {
+      onSelectionModeChange(mode);
+      // Reset selection when switching modes
+      if (onSelectedPostsChange) {
+        onSelectedPostsChange([]);
+      }
+      if (onShowPostSelectionChange) {
+        onShowPostSelectionChange(false);
+      }
+    }
+  };
 
   return (
     <div className="space-y-6">
@@ -56,100 +85,168 @@ export function AnalysisDepthPicker({
               title="Toggle analysis depth"
             >
               <h3 className="text-sm font-medium text-gray-900 dark:text-white group-hover:text-heycontent-yellow transition-colors">
-              Analysis Depth
-            </h3>
+                Analysis Depth
+              </h3>
               <ChevronDown className={`w-4 h-4 text-gray-500 group-hover:text-heycontent-yellow transition-all duration-200 ${!isCollapsed ? 'transform rotate-180' : ''}`} />
             </button>
           </div>
           <div className={`transition-all duration-300 ease-in-out overflow-hidden ${isCollapsed ? 'max-h-0' : 'max-h-96'}`}>
-            <div className="grid grid-cols-4 gap-1.5 mb-3">
-              {presetOptions.map((option) => (
+            
+            {/* Selection Mode Toggle */}
+            <div className="mb-4">
+              <div className="flex items-center gap-2 mb-2">
+                <span className="text-xs font-medium text-gray-700 dark:text-gray-300">Selection Mode:</span>
+              </div>
+              <div className="flex gap-2">
                 <button
-                  key={option.value}
-                  onClick={() => {
-                    setPostLimit(option.value);
-                    setShowCustomInput(false);
-                  }}
+                  onClick={() => handleSelectionModeChange('auto')}
                   disabled={isRefreshing}
-                  className={`relative group p-2 rounded-lg border transition-all duration-200 ${
-                    postLimit === option.value
-                      ? 'border-heycontent-yellow bg-heycontent-light-yellow/20'
-                      : 'border-gray-200 dark:border-gray-700 bg-white/50 dark:bg-gray-800/50 hover:border-heycontent-yellow/50'
+                  className={`flex items-center gap-2 px-3 py-2 rounded-lg text-xs font-medium transition-all duration-200 ${
+                    selectionMode === 'auto'
+                      ? 'bg-heycontent-yellow text-black'
+                      : 'bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-400 hover:bg-gray-200 dark:hover:bg-gray-700'
                   } ${isRefreshing ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'}`}
                 >
-                  <div className="text-center">
-                    <div
-                      className={`font-medium text-xs ${
-                        postLimit === option.value
-                          ? 'text-gray-900 dark:text-white'
-                          : 'text-gray-700 dark:text-gray-300'
-                      }`}
-                    >
-                      {option.label}
-                    </div>
-                  </div>
-                  {postLimit === option.value && (
-                    <div className="absolute -top-0.5 -right-0.5 w-3 h-3 bg-heycontent-yellow rounded-full flex items-center justify-center">
-                      <div className="w-1 h-1 bg-white rounded-full"></div>
-                    </div>
-                  )}
+                  <Auto className="w-3 h-3" />
+                  Auto Selection
                 </button>
-              ))}
-            </div>
-
-            <div className="flex items-center justify-between mb-2">
-              <button
-                onClick={() => setShowCustomInput(!showCustomInput)}
-                disabled={isRefreshing}
-                className={`flex items-center gap-1.5 px-2 py-1 rounded text-xs transition-colors ${
-                  showCustomInput
-                    ? 'bg-heycontent-light-yellow text-gray-900'
-                    : 'bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-400 hover:bg-gray-200 dark:hover:bg-gray-700'
-                } ${isRefreshing ? 'opacity-50 cursor-not-allowed' : ''}`}
-              >
-                <Settings className="w-3 h-3" />
-                Custom
-              </button>
-
-              <div className="flex items-center gap-1.5 px-2 py-1 bg-gray-50 dark:bg-gray-800 rounded text-xs">
-                <Zap className="w-3 h-3 text-heycontent-yellow" />
-                <span className="font-medium text-gray-900 dark:text-white">
-                  {typeof postLimit === 'number' ? `${postLimit} items` : 'All items'}
-                </span>
+                <button
+                  onClick={() => handleSelectionModeChange('manual')}
+                  disabled={isRefreshing}
+                  className={`flex items-center gap-2 px-3 py-2 rounded-lg text-xs font-medium transition-all duration-200 ${
+                    selectionMode === 'manual'
+                      ? 'bg-pink-500 text-white'
+                      : 'bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-400 hover:bg-gray-200 dark:hover:bg-gray-700'
+                  } ${isRefreshing ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'}`}
+                >
+                  <Grid3X3 className="w-3 h-3" />
+                  Manual Selection
+                </button>
               </div>
             </div>
 
-            {showCustomInput && (
-              <div className="p-3 bg-gray-50 dark:bg-gray-800/50 rounded-lg border border-gray-200 dark:border-gray-700">
-                <div className="flex items-center gap-2">
-                  <input
-                    id="custom-limit"
-                    type="number"
-                    min="1"
-                    max="20"
-                    value={customPostLimit}
-                    onChange={(e) => setCustomPostLimit(e.target.value)}
-                    onKeyPress={(e) => e.key === 'Enter' && handleCustomSubmit()}
-                    placeholder="e.g., 8"
-                    disabled={isRefreshing}
-                    className="flex-1 px-2 py-1 text-sm border border-gray-300 dark:border-gray-600 rounded bg-white dark:bg-gray-900 text-gray-900 dark:text-white placeholder-gray-500 dark:placeholder-gray-400 focus:ring-1 focus:ring-heycontent-yellow focus:border-transparent disabled:opacity-50 disabled:cursor-not-allowed"
-                  />
+            {/* Auto Selection Mode */}
+            {selectionMode === 'auto' && (
+              <>
+                <div className="grid grid-cols-4 gap-1.5 mb-3">
+                  {presetOptions.map((option) => (
+                    <button
+                      key={option.value}
+                      onClick={() => {
+                        setPostLimit(option.value);
+                        setShowCustomInput(false);
+                      }}
+                      disabled={isRefreshing}
+                      className={`relative group p-2 rounded-lg border transition-all duration-200 ${
+                        postLimit === option.value
+                          ? 'border-heycontent-yellow bg-heycontent-light-yellow/20'
+                          : 'border-gray-200 dark:border-gray-700 bg-white/50 dark:bg-gray-800/50 hover:border-heycontent-yellow/50'
+                      } ${isRefreshing ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'}`}
+                    >
+                      <div className="text-center">
+                        <div
+                          className={`font-medium text-xs ${
+                            postLimit === option.value
+                              ? 'text-gray-900 dark:text-white'
+                              : 'text-gray-700 dark:text-gray-300'
+                          }`}
+                        >
+                          {option.label}
+                        </div>
+                      </div>
+                      {postLimit === option.value && (
+                        <div className="absolute -top-0.5 -right-0.5 w-3 h-3 bg-heycontent-yellow rounded-full flex items-center justify-center">
+                          <div className="w-1 h-1 bg-white rounded-full"></div>
+                        </div>
+                      )}
+                    </button>
+                  ))}
+                </div>
+
+                <div className="flex items-center justify-between mb-2">
                   <button
-                    onClick={handleCustomSubmit}
-                    disabled={
-                      !customPostLimit ||
-                      isRefreshing ||
-                      parseInt(customPostLimit) < 1 ||
-                      parseInt(customPostLimit) > 20
-                    }
-                    className="px-3 py-1 bg-heycontent-yellow hover:bg-heycontent-yellow/90 text-black text-sm font-medium rounded transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                    onClick={() => setShowCustomInput(!showCustomInput)}
+                    disabled={isRefreshing}
+                    className={`flex items-center gap-1.5 px-2 py-1 rounded text-xs transition-colors ${
+                      showCustomInput
+                        ? 'bg-heycontent-light-yellow text-gray-900'
+                        : 'bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-400 hover:bg-gray-200 dark:hover:bg-gray-700'
+                    } ${isRefreshing ? 'opacity-50 cursor-not-allowed' : ''}`}
                   >
-                    Apply
+                    <Settings className="w-3 h-3" />
+                    Custom
+                  </button>
+
+                  <div className="flex items-center gap-1.5 px-2 py-1 bg-gray-50 dark:bg-gray-800 rounded text-xs">
+                    <Zap className="w-3 h-3 text-heycontent-yellow" />
+                    <span className="font-medium text-gray-900 dark:text-white">
+                      {typeof postLimit === 'number' ? `${postLimit} items` : 'All items'}
+                    </span>
+                  </div>
+                </div>
+
+                {showCustomInput && (
+                  <div className="p-3 bg-gray-50 dark:bg-gray-800/50 rounded-lg border border-gray-200 dark:border-gray-700">
+                    <div className="flex items-center gap-2">
+                      <input
+                        id="custom-limit"
+                        type="number"
+                        min="1"
+                        max="20"
+                        value={customPostLimit}
+                        onChange={(e) => setCustomPostLimit(e.target.value)}
+                        onKeyPress={(e) => e.key === 'Enter' && handleCustomSubmit()}
+                        placeholder="e.g., 8"
+                        disabled={isRefreshing}
+                        className="flex-1 px-2 py-1 text-sm border border-gray-300 dark:border-gray-600 rounded bg-white dark:bg-gray-900 text-gray-900 dark:text-white placeholder-gray-500 dark:placeholder-gray-400 focus:ring-1 focus:ring-heycontent-yellow focus:border-transparent disabled:opacity-50 disabled:cursor-not-allowed"
+                      />
+                      <button
+                        onClick={handleCustomSubmit}
+                        disabled={
+                          !customPostLimit ||
+                          isRefreshing ||
+                          parseInt(customPostLimit) < 1 ||
+                          parseInt(customPostLimit) > 20
+                        }
+                        className="px-3 py-1 bg-heycontent-yellow hover:bg-heycontent-yellow/90 text-black text-sm font-medium rounded transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                      >
+                        Apply
+                      </button>
+                    </div>
+                    <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+                      Maximum 20 posts allowed
+                    </p>
+                  </div>
+                )}
+              </>
+            )}
+
+            {/* Manual Selection Mode */}
+            {selectionMode === 'manual' && (
+              <div className="space-y-3">
+                <div className="flex items-center justify-between">
+                  <div className="flex items-center gap-2">
+                    <span className="text-sm font-medium text-gray-700 dark:text-gray-300">
+                      Selected Posts: {selectedPostIds.length} of 20
+                    </span>
+                  </div>
+                  <button
+                    onClick={() => onShowPostSelectionChange?.(!showPostSelection)}
+                    disabled={isRefreshing}
+                    className="flex items-center gap-2 px-3 py-1.5 bg-pink-500 hover:bg-pink-600 text-white text-xs font-medium rounded transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                  >
+                    <Grid3X3 className="w-3 h-3" />
+                    {showPostSelection ? 'Hide Selection' : 'Select Posts'}
                   </button>
                 </div>
-                <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
-                  Maximum 20 posts allowed
-                </p>
+                
+                {selectedPostIds.length > 0 && (
+                  <div className="p-3 bg-pink-50 dark:bg-pink-900/20 rounded-lg border border-pink-200 dark:border-pink-800">
+                    <p className="text-xs text-pink-700 dark:text-pink-300">
+                      {selectedPostIds.length} posts selected for analysis
+                    </p>
+                  </div>
+                )}
               </div>
             )}
           </div>

--- a/src/app/dashboard/ai-insights/_components/PostSelectionGrid.tsx
+++ b/src/app/dashboard/ai-insights/_components/PostSelectionGrid.tsx
@@ -1,0 +1,366 @@
+'use client'
+
+import React, { useState, useMemo } from 'react'
+import { Check, Search, Filter, SortAsc, SortDesc, Calendar, Heart, MessageCircle, Eye } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Badge } from '@/components/ui/badge'
+import { Card, CardContent } from '@/components/ui/card'
+import { Instagram } from 'lucide-react'
+import { formatNumber } from '@/lib/content-utils'
+
+interface InstagramPost {
+  postId: string
+  data: {
+    caption?: string
+    media_url?: string
+    thumbnail_url?: string
+    permalink?: string
+    timestamp?: number
+    like_count?: number
+    comments_count?: number
+    mediaType?: string
+    children?: Array<{
+      media_url?: string
+      thumbnail_url?: string
+      media_type?: string
+    }>
+  }
+  analysis?: any
+}
+
+interface PostSelectionGridProps {
+  posts: InstagramPost[]
+  selectedPosts: string[]
+  onSelectionChange: (selectedIds: string[]) => void
+  maxSelection: number
+  loading?: boolean
+}
+
+type SortOption = 'date' | 'engagement' | 'likes' | 'comments'
+type SortDirection = 'asc' | 'desc'
+
+export function PostSelectionGrid({
+  posts,
+  selectedPosts,
+  onSelectionChange,
+  maxSelection,
+  loading = false
+}: PostSelectionGridProps) {
+  const [searchTerm, setSearchTerm] = useState('')
+  const [sortBy, setSortBy] = useState<SortOption>('date')
+  const [sortDirection, setSortDirection] = useState<SortDirection>('desc')
+  const [mediaTypeFilter, setMediaTypeFilter] = useState<string>('all')
+
+  // Filter and sort posts
+  const filteredAndSortedPosts = useMemo(() => {
+    let filtered = posts.filter(post => {
+      const matchesSearch = !searchTerm || 
+        post.data.caption?.toLowerCase().includes(searchTerm.toLowerCase()) ||
+        post.postId.toLowerCase().includes(searchTerm.toLowerCase())
+      
+      const matchesMediaType = mediaTypeFilter === 'all' || 
+        post.data.mediaType?.toLowerCase() === mediaTypeFilter.toLowerCase()
+      
+      return matchesSearch && matchesMediaType
+    })
+
+    // Sort posts
+    filtered.sort((a, b) => {
+      let aValue: any
+      let bValue: any
+
+      switch (sortBy) {
+        case 'date':
+          aValue = a.data.timestamp || 0
+          bValue = b.data.timestamp || 0
+          break
+        case 'engagement':
+          aValue = (a.data.like_count || 0) + (a.data.comments_count || 0)
+          bValue = (b.data.like_count || 0) + (b.data.comments_count || 0)
+          break
+        case 'likes':
+          aValue = a.data.like_count || 0
+          bValue = b.data.like_count || 0
+          break
+        case 'comments':
+          aValue = a.data.comments_count || 0
+          bValue = b.data.comments_count || 0
+          break
+        default:
+          aValue = a.data.timestamp || 0
+          bValue = b.data.timestamp || 0
+      }
+
+      if (sortDirection === 'asc') {
+        return aValue - bValue
+      } else {
+        return bValue - aValue
+      }
+    })
+
+    return filtered
+  }, [posts, searchTerm, sortBy, sortDirection, mediaTypeFilter])
+
+  // Selection handlers
+  const handlePostToggle = (postId: string) => {
+    const newSelection = selectedPosts.includes(postId)
+      ? selectedPosts.filter(id => id !== postId)
+      : selectedPosts.length < maxSelection
+        ? [...selectedPosts, postId]
+        : selectedPosts
+
+    onSelectionChange(newSelection)
+  }
+
+  const handleSelectAll = () => {
+    const availablePosts = filteredAndSortedPosts.slice(0, maxSelection)
+    const newSelection = availablePosts.map(post => post.postId)
+    onSelectionChange(newSelection)
+  }
+
+  const handleClearAll = () => {
+    onSelectionChange([])
+  }
+
+  const handleSelectByEngagement = () => {
+    const topPosts = filteredAndSortedPosts
+      .sort((a, b) => {
+        const aEngagement = (a.data.like_count || 0) + (a.data.comments_count || 0)
+        const bEngagement = (b.data.like_count || 0) + (b.data.comments_count || 0)
+        return bEngagement - aEngagement
+      })
+      .slice(0, maxSelection)
+      .map(post => post.postId)
+    
+    onSelectionChange(topPosts)
+  }
+
+  // Get media URL for display
+  const getMediaUrl = (post: InstagramPost) => {
+    if (post.data.children && post.data.children.length > 0) {
+      return post.data.children[0].media_url || post.data.children[0].thumbnail_url
+    }
+    return post.data.media_url || post.data.thumbnail_url
+  }
+
+  // Format date
+  const formatDate = (timestamp?: number) => {
+    if (!timestamp) return 'Unknown date'
+    return new Date(timestamp * 1000).toLocaleDateString()
+  }
+
+  // Get media type display
+  const getMediaTypeDisplay = (mediaType?: string) => {
+    if (!mediaType) return 'Post'
+    switch (mediaType.toUpperCase()) {
+      case 'IMAGE': return 'Image'
+      case 'VIDEO': return 'Video'
+      case 'CAROUSEL_ALBUM': return 'Carousel'
+      case 'REELS': return 'Reel'
+      default: return mediaType
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="space-y-4">
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+          {Array.from({ length: 6 }).map((_, i) => (
+            <Card key={i} className="animate-pulse">
+              <CardContent className="p-4">
+                <div className="aspect-square bg-gray-200 rounded-lg mb-3" />
+                <div className="h-4 bg-gray-200 rounded mb-2" />
+                <div className="h-3 bg-gray-200 rounded w-2/3" />
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-4">
+      {/* Controls */}
+      <div className="flex flex-col sm:flex-row gap-4 items-start sm:items-center justify-between">
+        {/* Search and Filters */}
+        <div className="flex flex-col sm:flex-row gap-2 flex-1">
+          <div className="relative">
+            <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 w-4 h-4 text-gray-400" />
+            <Input
+              placeholder="Search posts..."
+              value={searchTerm}
+              onChange={(e) => setSearchTerm(e.target.value)}
+              className="pl-10 w-full sm:w-64"
+            />
+          </div>
+          
+          <select
+            value={mediaTypeFilter}
+            onChange={(e) => setMediaTypeFilter(e.target.value)}
+            className="px-3 py-2 border border-gray-300 rounded-md text-sm"
+          >
+            <option value="all">All Types</option>
+            <option value="image">Images</option>
+            <option value="video">Videos</option>
+            <option value="carousel">Carousels</option>
+            <option value="reels">Reels</option>
+          </select>
+        </div>
+
+        {/* Sort Controls */}
+        <div className="flex items-center gap-2">
+          <select
+            value={sortBy}
+            onChange={(e) => setSortBy(e.target.value as SortOption)}
+            className="px-3 py-2 border border-gray-300 rounded-md text-sm"
+          >
+            <option value="date">Date</option>
+            <option value="engagement">Engagement</option>
+            <option value="likes">Likes</option>
+            <option value="comments">Comments</option>
+          </select>
+          
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => setSortDirection(sortDirection === 'asc' ? 'desc' : 'asc')}
+          >
+            {sortDirection === 'asc' ? <SortAsc className="w-4 h-4" /> : <SortDesc className="w-4 h-4" />}
+          </Button>
+        </div>
+      </div>
+
+      {/* Selection Controls */}
+      <div className="flex flex-wrap gap-2 items-center">
+        <Badge variant="outline" className="text-sm">
+          {selectedPosts.length} of {maxSelection} selected
+        </Badge>
+        
+        <div className="flex gap-2">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={handleSelectAll}
+            disabled={selectedPosts.length >= maxSelection}
+          >
+            Select All
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={handleClearAll}
+            disabled={selectedPosts.length === 0}
+          >
+            Clear All
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={handleSelectByEngagement}
+            disabled={selectedPosts.length >= maxSelection}
+          >
+            Top by Engagement
+          </Button>
+        </div>
+      </div>
+
+      {/* Posts Grid */}
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
+        {filteredAndSortedPosts.map((post) => {
+          const isSelected = selectedPosts.includes(post.postId)
+          const mediaUrl = getMediaUrl(post)
+          const isCarousel = post.data.children && post.data.children.length > 1
+
+          return (
+            <Card
+              key={post.postId}
+              className={`cursor-pointer transition-all duration-200 hover:shadow-md ${
+                isSelected ? 'ring-2 ring-pink-500 bg-pink-50' : 'hover:bg-gray-50'
+              }`}
+              onClick={() => handlePostToggle(post.postId)}
+            >
+              <CardContent className="p-0">
+                {/* Media */}
+                <div className="relative aspect-square">
+                  {mediaUrl ? (
+                    <img
+                      src={mediaUrl}
+                      alt={post.data.caption || 'Instagram post'}
+                      className="w-full h-full object-cover rounded-t-lg"
+                    />
+                  ) : (
+                    <div className="w-full h-full bg-gray-200 rounded-t-lg flex items-center justify-center">
+                      <Instagram className="w-8 h-8 text-gray-400" />
+                    </div>
+                  )}
+                  
+                  {/* Selection Indicator */}
+                  <div className="absolute top-2 right-2">
+                    <div className={`w-6 h-6 rounded-full flex items-center justify-center ${
+                      isSelected 
+                        ? 'bg-pink-500 text-white' 
+                        : 'bg-white/80 text-gray-400 border border-gray-300'
+                    }`}>
+                      {isSelected && <Check className="w-4 h-4" />}
+                    </div>
+                  </div>
+
+                  {/* Carousel Indicator */}
+                  {isCarousel && (
+                    <div className="absolute top-2 left-2 bg-black/60 text-white text-xs px-2 py-1 rounded">
+                      {post.data.children?.length || 0} photos
+                    </div>
+                  )}
+
+                  {/* Media Type Badge */}
+                  <div className="absolute bottom-2 left-2 bg-black/60 text-white text-xs px-2 py-1 rounded">
+                    {getMediaTypeDisplay(post.data.mediaType)}
+                  </div>
+                </div>
+
+                {/* Content */}
+                <div className="p-3">
+                  {/* Caption */}
+                  <p className="text-sm text-gray-700 line-clamp-2 mb-2">
+                    {post.data.caption || 'No caption'}
+                  </p>
+
+                  {/* Stats */}
+                  <div className="flex items-center gap-4 text-xs text-gray-500">
+                    <div className="flex items-center gap-1">
+                      <Heart className="w-3 h-3" />
+                      <span>{formatNumber(post.data.like_count || 0)}</span>
+                    </div>
+                    <div className="flex items-center gap-1">
+                      <MessageCircle className="w-3 h-3" />
+                      <span>{formatNumber(post.data.comments_count || 0)}</span>
+                    </div>
+                    <div className="flex items-center gap-1">
+                      <Calendar className="w-3 h-3" />
+                      <span>{formatDate(post.data.timestamp)}</span>
+                    </div>
+                  </div>
+                </div>
+              </CardContent>
+            </Card>
+          )
+        })}
+      </div>
+
+      {/* Empty State */}
+      {filteredAndSortedPosts.length === 0 && (
+        <div className="text-center py-8">
+          <Instagram className="w-12 h-12 text-gray-400 mx-auto mb-4" />
+          <p className="text-gray-500">
+            {searchTerm || mediaTypeFilter !== 'all' 
+              ? 'No posts match your filters. Try adjusting your search or filters.'
+              : 'No Instagram posts found. Connect your account to get started!'
+            }
+          </p>
+        </div>
+      )}
+    </div>
+  )
+} 

--- a/src/app/dashboard/ai-insights/_components/hooks/useInstagramInsights.ts
+++ b/src/app/dashboard/ai-insights/_components/hooks/useInstagramInsights.ts
@@ -109,7 +109,7 @@ export function useInstagramInsights(userId?: string): BatchAnalysisHookReturn {
     }
   }, [isRefreshing, databaseStatus]);
 
-  const refresh = useCallback(async () => {
+  const refresh = useCallback(async (selectionMode?: 'auto' | 'manual', selectedPostIds?: string[]) => {
     if (!userId || !instagramAccount?.instagramAccountId) {
       setError('Your Instagram account isn\'t connected yet. No worries—let\'s get you set up so you can unlock those amazing insights! 🚀');
       return;
@@ -131,20 +131,33 @@ export function useInstagramInsights(userId?: string): BatchAnalysisHookReturn {
 
       const backendUrl = process.env.NEXT_PUBLIC_BACKEND_URL || 'http://localhost:8000';
       
+      // Prepare request body based on selection mode
+      const requestBody: any = {
+        user_id: userId,
+        instagram_account_id: instagramAccount.instagramAccountId,
+        include_stories: true,
+        include_comments: true,
+        force_refresh: false // Don't force refresh to avoid unnecessary API calls
+      };
+
+      if (selectionMode === 'manual' && selectedPostIds && selectedPostIds.length > 0) {
+        // Manual selection mode
+        requestBody.selection_mode = 'manual';
+        requestBody.selected_post_ids = selectedPostIds;
+        // For manual mode, we don't use max_posts since we're selecting specific posts
+      } else {
+        // Auto selection mode
+        requestBody.selection_mode = 'auto';
+        requestBody.max_posts = typeof postLimit === 'number' ? Math.min(postLimit, 20) : 5; // Enforce hard limit of 20
+      }
+      
       const response = await fetch(`${backendUrl}/api/v1/instagram/account-insights`, {
         method: 'POST',
         headers: { 
           'Content-Type': 'application/json',
           'Authorization': `Bearer ${apiKey}`
         },
-        body: JSON.stringify({
-          user_id: userId,
-          instagram_account_id: instagramAccount.instagramAccountId,
-          max_posts: typeof postLimit === 'number' ? Math.min(postLimit, 20) : 5, // Enforce hard limit of 20
-          include_stories: true,
-          include_comments: true,
-          force_refresh: false // Don't force refresh to avoid unnecessary API calls
-        }),
+        body: JSON.stringify(requestBody),
       });
 
       const data = await response.json();

--- a/src/app/dashboard/ai-insights/_components/platforms/InstagramPlatform.tsx
+++ b/src/app/dashboard/ai-insights/_components/platforms/InstagramPlatform.tsx
@@ -8,6 +8,7 @@ import { useActionStepDiscussion } from '../hooks/useActionStepDiscussion'
 import { RefreshState } from '@/components/ui/refresh-state'
 import { Skeleton } from '@/components/ui/skeleton'
 import { AnalysisDepthPicker } from '../AnalysisDepthPicker'
+import { PostSelectionGrid } from '../PostSelectionGrid'
 import { Instagram } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { PlatformConnectionPrompt } from '../../../_components/content-hub/PlatformConnectionPrompt'
@@ -15,6 +16,8 @@ import { useInstagramBreakdowns } from '../hooks/useInstagramBreakdowns'
 import InstagramDemographics from '../../../content-analytics/components/InstagramDemographics'
 import { toast } from 'sonner';
 import { getApiKey, getCurrentUserId, fetchWithApiKey } from '@/app/lib/api-helpers';
+import { useQuery } from 'convex/react';
+import { api } from '@/convex/_generated/api';
 
 
 interface InstagramPlatformProps {
@@ -30,6 +33,11 @@ export function InstagramPlatform({ userId: propUserId, currentQuote, loading }:
   const { navigateWithInsight } = useInsightNavigation()
   const { discussActionStep } = useActionStepDiscussion()
   const [refreshingDemographics, setRefreshingDemographics] = useState(false);
+
+  // Post selection state
+  const [selectionMode, setSelectionMode] = useState<'auto' | 'manual'>('auto')
+  const [selectedPostIds, setSelectedPostIds] = useState<string[]>([])
+  const [showPostSelection, setShowPostSelection] = useState(false)
 
   const {
     insights,
@@ -47,6 +55,12 @@ export function InstagramPlatform({ userId: propUserId, currentQuote, loading }:
   } = useInstagramInsights(userId);
 
   const breakdowns = useInstagramBreakdowns(userId);
+
+  // Fetch available Instagram posts for selection
+  const availablePosts = useQuery(
+    api.instagramQueries.getAllInstagramPosts,
+    userId ? { userId } : "skip"
+  );
 
   // Transform AI Insights breakdowns data to match InstagramDemographics component format
   const transformedDemographicsData = React.useMemo(() => {
@@ -90,7 +104,17 @@ export function InstagramPlatform({ userId: propUserId, currentQuote, loading }:
     if (!isConnected) {
       window.location.href = '/settings?tab=integrations';
     } else {
-      refresh();
+      // Enhanced refresh function that handles both auto and manual modes
+      if (selectionMode === 'auto') {
+        refresh();
+      } else {
+        // For manual mode, pass selected post IDs
+        if (selectedPostIds.length === 0) {
+          toast.error('Please select at least one post for analysis! 🎯');
+          return;
+        }
+        refresh('manual', selectedPostIds);
+      }
     }
   };
 
@@ -125,7 +149,7 @@ export function InstagramPlatform({ userId: propUserId, currentQuote, loading }:
             <Instagram className="w-full h-full text-pink-500" />
           </div>
         }
-        description="Connect your Instagram account to unlock a world of insights, celebrate your creative journey, and discover new ways to shine. Your next big idea is just a connection away—let’s make magic together!"
+        description="Connect your Instagram account to unlock a world of insights, celebrate your creative journey, and discover new ways to shine. Your next big idea is just a connection away—let's make magic together!"
         buttonColor="bg-pink-600"
         buttonHoverColor="hover:bg-pink-700"
       />
@@ -191,9 +215,35 @@ export function InstagramPlatform({ userId: propUserId, currentQuote, loading }:
               showCustomInput={showCustomInput}
               setShowCustomInput={setShowCustomInput}
               handleCustomSubmit={handleCustomSubmit}
+              // New props for manual selection
+              selectionMode={selectionMode}
+              onSelectionModeChange={setSelectionMode}
+              selectedPostIds={selectedPostIds}
+              onSelectedPostsChange={setSelectedPostIds}
+              availablePosts={availablePosts || []}
+              showPostSelection={showPostSelection}
+              onShowPostSelectionChange={setShowPostSelection}
             />
           )}
         </div>
+
+        {/* Post Selection Grid */}
+        {selectionMode === 'manual' && showPostSelection && availablePosts && (
+          <div className="border-t border-border pt-6">
+            <h3 className="text-lg font-semibold mb-4">Select Posts for Analysis</h3>
+            <PostSelectionGrid
+              posts={availablePosts.map(post => ({
+                postId: post.postId || post._id,
+                data: post.data || {},
+                analysis: post.analysis
+              }))}
+              selectedPosts={selectedPostIds}
+              onSelectionChange={setSelectedPostIds}
+              maxSelection={20}
+              loading={!availablePosts}
+            />
+          </div>
+        )}
 
         {/* Analysis Results */}
         {!refreshing && (
@@ -214,7 +264,7 @@ export function InstagramPlatform({ userId: propUserId, currentQuote, loading }:
               {(insights || []).length === 0 && !error && (
                 <div className="text-center text-muted-foreground py-8 border-2 border-dashed border-muted-foreground/20 rounded-lg">
                   <p className="text-lg font-medium mb-2">No insights here yet—your creative journey is just getting started!</p>
-                  <p>When you run an analysis, you’ll unlock fresh ideas and new ways to shine. Keep creating—your next breakthrough is just around the corner! 🌟</p>
+                  <p>When you run an analysis, you'll unlock fresh ideas and new ways to shine. Keep creating—your next breakthrough is just around the corner! 🌟</p>
                 </div>
               )}
               {(insights || []).map((insight, idx) => (

--- a/src/types/batch-analysis.ts
+++ b/src/types/batch-analysis.ts
@@ -55,7 +55,7 @@ export interface BatchAnalysisHookReturn {
   refreshing: boolean;
   error: string | null;
   isConnected: boolean;
-  refresh: () => void;
+  refresh: (selectionMode?: 'auto' | 'manual', selectedPostIds?: string[]) => void;
   // Platform-specific controls
   postLimit?: number | 'all';
   setPostLimit?: (limit: number | 'all') => void;


### PR DESCRIPTION
- Introduced new fields in BatchAnalysisRequest and AccountInsightsRequest for manual selection of posts, allowing users to specify selection mode ('auto' or 'manual') and provide a list of selected post IDs.
- Updated the run_instagram_batch_analysis and get_account_insights functions to handle manual selection logic, ensuring appropriate error handling and logging for both selection modes.
- Enhanced user experience by providing clear feedback when no posts are selected or found during manual analysis.

These changes improve the flexibility and usability of the Instagram batch analysis feature.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added manual post selection mode for Instagram analysis, allowing users to pick up to 20 specific posts for insights.
  * Introduced a new interface for browsing, filtering, sorting, and selecting Instagram posts.
  * Users can now toggle between automatic and manual selection modes with an updated UI.

* **Improvements**
  * Enhanced feedback and controls for post selection, including search, sorting, and media type filtering.
  * Updated user-facing text for clarity and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->