### PR TITLE
Implement defensive cleanup for active note management in Notes conte…

### DIFF
--- a/src/app/context/notes-context.tsx
+++ b/src/app/context/notes-context.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { createContext, useContext, useCallback, useState } from 'react';
+import { usePathname } from 'next/navigation';
 import { useSmartNotes } from '@/app/dashboard/notes/hooks/useSmartNotes';
 import { Note, NoteUpdate } from '@/app/dashboard/notes/types';
 import type { Id } from '@/convex/_generated/dataModel';
@@ -40,6 +41,7 @@ const NotesContext = createContext<NotesContextType | undefined>(undefined);
 export const NotesProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const { firebaseUser } = useAuth();
   const userId = firebaseUser?.uid;
+  const pathname = usePathname();
   const {
     notes,
     isLoading,
@@ -56,6 +58,15 @@ export const NotesProvider: React.FC<{ children: React.ReactNode }> = ({ childre
   const [navigationStack, setNavigationStack] = useState<NavigationEntry[]>([]);
 
   const convexDeleteNote = useMutation(api.notes.deleteNote);
+
+  // Clear activeNoteId when navigating away from notes route
+  React.useEffect(() => {
+    if (pathname && !pathname.startsWith('/dashboard/notes') && activeNoteId) {
+      console.log('🔄 Route changed away from notes, clearing active note:', { from: pathname, activeNoteId });
+      setActiveNoteId(undefined);
+      setNavigationStack([]); // Also clear navigation stack
+    }
+  }, [pathname, activeNoteId, setActiveNoteId]);
 
   // Delete note: just call Convex, let reactivity update notes
   const deleteNote = useCallback(async (noteId: Id<'notes'> | string): Promise<boolean> => {

--- a/src/app/dashboard/notes/index.tsx
+++ b/src/app/dashboard/notes/index.tsx
@@ -7,7 +7,7 @@ import { useAuth } from '@/app/context/auth-context';
 import type { Id } from '@/convex/_generated/dataModel';
 import { useNotes } from '@/app/context/notes-context';
 import { Note } from './types';
-import { useSearchParams, useRouter } from 'next/navigation';
+import { useSearchParams, useRouter, usePathname } from 'next/navigation';
 import { YouTubeVideoCard } from './components/YouTubeVideoCard';
 import { InstagramPostCard } from './components/InstagramPostCard';
 import { GmailThreadCard } from './components/GmailThreadCard';
@@ -30,6 +30,7 @@ export default function SmartNotes() {
   const fromProject = searchParams.get('fromProject') === 'true';
   const projectId = searchParams.get('projectId');
   const router = useRouter();
+  const pathname = usePathname();
 
   const {
     notes,
@@ -81,6 +82,17 @@ export default function SmartNotes() {
       }
     }
   }, [noteIdParam, notes, setActiveNoteId]);
+
+  // Clear activeNoteId when navigating away from notes route (defensive cleanup)
+  React.useEffect(() => {
+    return () => {
+      // Cleanup on unmount - ensure no note is active when leaving the component
+      if (activeNoteId) {
+        console.log('🧹 Notes component unmounting, clearing active note');
+        setActiveNoteId(undefined);
+      }
+    };
+  }, []);
 
   // Helper to clear noteId from URL
   const clearNoteIdFromUrl = React.useCallback(() => {


### PR DESCRIPTION
…xt and SmartNotes component

- Added logic to clear `activeNoteId` and navigation stack when navigating away from the notes route in `NotesProvider`.
- Implemented cleanup effect in `SmartNotes` component to ensure no active note remains when the component unmounts.

These changes enhance user experience by preventing stale state and ensuring a clean transition between routes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured that the active note and navigation history are cleared when navigating away from the notes section, preventing stale state from persisting.
  * Improved state cleanup when leaving the notes component to enhance user experience and prevent potential confusion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->