### PR TITLE
Revert "Revert "Add manual metadata generation functionality to notes context and UI (#XXX) (#531)""

### DIFF
--- a/src/app/context/notes-context.tsx
+++ b/src/app/context/notes-context.tsx
@@ -31,6 +31,9 @@ interface NotesContextType {
   navigationStack: NavigationEntry[];
   canNavigateBack: boolean;
   clearNavigationStack: () => void;
+  // Manual metadata generation functions
+  generateMetadataManually: (noteId: string, noteContent: string) => Promise<boolean>;
+  isGeneratingMetadata: boolean;
 }
 
 const NotesContext = createContext<NotesContextType | undefined>(undefined);
@@ -47,6 +50,8 @@ export const NotesProvider: React.FC<{ children: React.ReactNode }> = ({ childre
     updateNote,
     activeNoteId,
     setActiveNoteId,
+    generateMetadataManually,
+    isGeneratingMetadata,
   } = useSmartNotes(userId);
 
   // Navigation stack state
@@ -189,6 +194,8 @@ export const NotesProvider: React.FC<{ children: React.ReactNode }> = ({ childre
     navigationStack,
     canNavigateBack,
     clearNavigationStack,
+    generateMetadataManually,
+    isGeneratingMetadata,
   };
 
   return (

--- a/src/app/dashboard/notes/NoteArea.tsx
+++ b/src/app/dashboard/notes/NoteArea.tsx
@@ -10,12 +10,12 @@ import { RichTextEditor } from '@/components/ui/rich-text-editor/rich-text-edito
 import { NoteMeta } from './components/NoteMeta';
 import { TypeSelector } from './components/TypeSelector';
 import { ImageGalleryModal } from './components/ImageGalleryModal';
-import { Image } from 'lucide-react';
+import { Image, Wand2, Loader2 } from 'lucide-react';
 import type { Id } from "@/convex/_generated/dataModel";
 import { useNotes } from '@/app/context/notes-context';
-import { useAuth } from '@/app/context/auth-context';
 import { NoteContentRenderer } from './components/NoteContentRenderer';
 import { useContentResolver } from '@/lib/content-resolver';
+import { getCurrentUserId } from '@/app/lib/api-helpers';
 
 interface NoteAreaProps {
   note: Note;
@@ -202,7 +202,7 @@ export function NoteArea({
   forcePreview = false,
 }: NoteAreaProps) {
   // Get all notes from context for tag suggestions
-  const { notes, canNavigateBack, navigationStack } = useNotes();
+  const { notes, canNavigateBack, navigationStack, generateMetadataManually, isGeneratingMetadata } = useNotes();
   // Use the live query conditionally with "skip" parameter to avoid conditional hook call
   const liveNoteData = useQuery(
     api.notes.getNote, 
@@ -289,6 +289,27 @@ export function NoteArea({
     onSave(content, note.title);
   };
 
+  // Smart Title + Tags button logic
+  const shouldShowSmartButton = useMemo(() => {
+    // Show button if content has ≥10 characters
+    const hasEnoughContent = content.trim().length >= 10;
+    
+    // Always show if content is sufficient - let user decide if they want to regenerate
+    return hasEnoughContent && !note.isTemporary;
+  }, [content, note.isTemporary]);
+
+  const handleGenerateMetadata = useCallback(async () => {
+    if (!shouldShowSmartButton || isGeneratingMetadata) return;
+    
+    await flush(); // Save current content first
+    const success = await generateMetadataManually(String(note._id), content.trim());
+    
+    if (success) {
+      // The API will update the note automatically, and the UI will reflect the changes
+      // due to the live query updating the note data
+    }
+  }, [shouldShowSmartButton, isGeneratingMetadata, flush, generateMetadataManually, note._id, content]);
+
   // AI handlers that return values for RichTextEditor
   const handleAskAI = useCallback(async (prompt: string) => {
     try {
@@ -334,8 +355,7 @@ export function NoteArea({
     onBack(content);
   };
 
-  const { firebaseUser } = useAuth();
-  const userId = firebaseUser?.uid;
+  const userId = getCurrentUserId();
   const { allContent: allLinkableContent } = useContentResolver(userId);
 
   React.useEffect(() => {
@@ -388,13 +408,37 @@ export function NoteArea({
           noteTagData={noteTagData}
         />
         
-        <TypeSelector
-          noteId={note._id}
-          userId={note.userId}
-          currentType={note.type || 'idea_bank'}
-          typeGenerated={note.typeGenerated}
-          onTypeChange={handleTypeChange}
-        />
+        {/* Smart Title + Tags Button */}
+        <div className="flex items-center gap-3">
+          {shouldShowSmartButton && (
+            <button
+              onClick={handleGenerateMetadata}
+              disabled={isGeneratingMetadata}
+              className="inline-flex items-center gap-2 px-3 py-1.5 text-sm font-medium bg-background hover:bg-muted text-foreground border border-border rounded-md transition-all duration-200 hover:shadow-sm disabled:opacity-50 disabled:cursor-not-allowed"
+              title="Generate smart title and tags using AI"
+            >
+              {isGeneratingMetadata ? (
+                <>
+                  <Loader2 size={14} className="animate-spin" />
+                  <span>Generating...</span>
+                </>
+              ) : (
+                <>
+                  <Wand2 size={14} />
+                  <span>Smart Title + Tags</span>
+                </>
+              )}
+            </button>
+          )}
+          
+          <TypeSelector
+            noteId={note._id}
+            userId={note.userId}
+            currentType={note.type || 'idea_bank'}
+            typeGenerated={note.typeGenerated}
+            onTypeChange={handleTypeChange}
+          />
+        </div>
       </div>
       
       {/* Main editor area */}

--- a/src/app/dashboard/notes/hooks/useSmartNotes.ts
+++ b/src/app/dashboard/notes/hooks/useSmartNotes.ts
@@ -15,6 +15,9 @@ interface SmartNotesHook {
   updateNote: (noteId: string | Id<"notes">, updateFields: NoteUpdate, force?: boolean) => Promise<Note | null>;
   activeNoteId: string | undefined;
   setActiveNoteId: (id: string | undefined) => void;
+  // Manual metadata generation functions
+  generateMetadataManually: (noteId: string, noteContent: string) => Promise<boolean>;
+  isGeneratingMetadata: boolean;
 }
 
 export function useSmartNotes(userId: string | undefined): SmartNotesHook {
@@ -24,6 +27,7 @@ export function useSmartNotes(userId: string | undefined): SmartNotesHook {
   // State variables
   const [isSaving, setIsSaving] = useState<boolean>(false);
   const [activeNoteId, setActiveNoteId] = useState<string | undefined>(undefined);
+  const [isGeneratingMetadata, setIsGeneratingMetadata] = useState<boolean>(false);
 
   // Convex mutations
   const createNoteConvex = useMutation(api.noteMutations.createNote);
@@ -60,17 +64,18 @@ export function useSmartNotes(userId: string | undefined): SmartNotesHook {
     });
   }, [notesFromConvex]);
 
-  // Debounced metadata generation
-  const generateMetadata = useCallback(
-    (noteId: string, noteContent: string) => {
-
-      
+  // Manual metadata generation function
+  const generateMetadataManually = useCallback(
+    async (noteId: string, noteContent: string): Promise<boolean> => {
       // Skip if content is too short
-      if (!noteContent || noteContent.trim().length < 10) return;
+      if (!noteContent || noteContent.trim().length < 10) {
+        toast.error("Need at least 10 characters to generate smart title and tags.");
+        return false;
+      }
       
       // PREVENT DUPLICATES
       if (metadataPending.current[noteId]) {
-        return;
+        return false;
       }
       
       // Cancel any existing request for this note
@@ -84,52 +89,56 @@ export function useSmartNotes(userId: string | undefined): SmartNotesHook {
         clearTimeout(metadataTimers.current[noteId]);
       }
       
-      // Set up new debounced request
-      metadataTimers.current[noteId] = setTimeout(async () => {
-        const controller = new AbortController();
-        abortControllers.current[noteId] = controller;
-        metadataPending.current[noteId] = true;
-        
-        try {
-          const apiKey = await getApiKey();
-          if (!apiKey) {
-            toast.error("Please sign in again to generate metadata.");
-            return;
-          }
-
-          const response = await fetch('/api/smart-notes/generate-metadata', {
-            method: 'POST',
-            headers: {
-              'Content-Type': 'application/json',
-              'Authorization': `Bearer ${apiKey}`,
-            },
-            body: JSON.stringify({ noteId, noteContent }),
-            signal: controller.signal,
-          });
-
-          if (!response.ok) {
-            const errorData = await response.json();
-            const friendlyError = errorData.message?.includes('rate limit')
-              ? "We're getting lots of love from creators right now! Please take a quick break and try again in a moment. 🎨✨"
-              : errorData.message || "We hit a creative block while generating insights. Your work is safe - please try again!";
-            toast.error(friendlyError);
-          }
-        } catch (error) {
-          if (error instanceof Error && error.name === 'AbortError') {
-            // Request was cancelled, ignore
-            return;
-          }
-          
-          const errorMessage = error instanceof Error ? error.message : String(error);
-          const friendlyError = errorMessage.includes('rate limit')
-            ? "We're getting lots of love from creators right now! Please take a quick break and try again in a moment. 🎨✨"
-            : `We hit a creative block: ${errorMessage}. Your work is safe - please try again!`;
-          toast.error(friendlyError);
-        } finally {
-          delete abortControllers.current[noteId];
-          delete metadataPending.current[noteId];
+      setIsGeneratingMetadata(true);
+      const controller = new AbortController();
+      abortControllers.current[noteId] = controller;
+      metadataPending.current[noteId] = true;
+      
+      try {
+        const apiKey = await getApiKey();
+        if (!apiKey) {
+          toast.error("Please sign in again to generate metadata.");
+          return false;
         }
-      }, 500); // 500ms debounce
+
+        const response = await fetch('/api/smart-notes/generate-metadata', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'Authorization': `Bearer ${apiKey}`,
+          },
+          body: JSON.stringify({ noteId, noteContent }),
+          signal: controller.signal,
+        });
+
+        if (!response.ok) {
+          const errorData = await response.json();
+          const friendlyError = errorData.message?.includes('rate limit')
+            ? "We're getting lots of love from creators right now! Please take a quick break and try again in a moment. 🎨✨"
+            : errorData.message || "We hit a creative block while generating insights. Your work is safe - please try again!";
+          toast.error(friendlyError);
+          return false;
+        }
+
+        toast.success("✨ Smart title and tags generated!");
+        return true;
+      } catch (error) {
+        if (error instanceof Error && error.name === 'AbortError') {
+          // Request was cancelled, ignore
+          return false;
+        }
+        
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        const friendlyError = errorMessage.includes('rate limit')
+          ? "We're getting lots of love from creators right now! Please take a quick break and try again in a moment. 🎨✨"
+          : `We hit a creative block: ${errorMessage}. Your work is safe - please try again!`;
+        toast.error(friendlyError);
+        return false;
+      } finally {
+        delete abortControllers.current[noteId];
+        delete metadataPending.current[noteId];
+        setIsGeneratingMetadata(false);
+      }
     },
     []
   );
@@ -160,7 +169,7 @@ export function useSmartNotes(userId: string | undefined): SmartNotesHook {
     }
   }, [userId, createNoteConvex]);
 
-  // Update existing note
+  // Update existing note (auto-triggering logic removed)
   const updateNote = useCallback(async (
     noteId: string | Id<"notes">,
     updateFields: NoteUpdate,
@@ -189,23 +198,7 @@ export function useSmartNotes(userId: string | undefined): SmartNotesHook {
         updates: cleanedUpdateFields,
       });
 
-      // 🎯 PERFECT METADATA LOGIC: Only generate when both flags are false (first time only)
-      // This prevents regeneration while allowing first-time generation for existing notes
-      const isManualTitleChange = !!updateFields.title;
-      const isManualTypeChange = !!updateFields.type;
-      const isContentOnlyUpdate = updateFields.content && !isManualTitleChange && !isManualTypeChange;
-      
-      const shouldGenerateMetadata = !force && 
-        isContentOnlyUpdate && 
-        updateFields.content.trim().length >= 10 && 
-        !updatedNote?.titleGenerated && 
-        !updatedNote?.typeGenerated; // CRITICAL: Both must be false (AND logic)
-      
-
-      
-      if (shouldGenerateMetadata) {
-        generateMetadata(String(noteId), updateFields.content.trim());
-      }
+      // AUTO-TRIGGERING LOGIC REMOVED - Now only manual generation via button
 
       return updatedNote as Note;
     } catch (error) {
@@ -215,7 +208,7 @@ export function useSmartNotes(userId: string | undefined): SmartNotesHook {
     } finally {
       setIsSaving(false);
     }
-  }, [userId, updateNoteConvex, generateMetadata]);
+  }, [userId, updateNoteConvex]);
 
   // Cleanup on unmount
   useEffect(() => {
@@ -234,5 +227,7 @@ export function useSmartNotes(userId: string | undefined): SmartNotesHook {
     updateNote,
     activeNoteId,
     setActiveNoteId,
+    generateMetadataManually,
+    isGeneratingMetadata,
   };
 }


### PR DESCRIPTION
This reverts commit 667baecbcf4f651fdcdb291394f0d36c497d08de.

This pull request introduces a new feature for manually generating metadata (smart titles and tags) for notes, along with several related updates to the context, hooks, and UI. The changes include adding a button to trigger metadata generation, modifying the `useSmartNotes` hook to support manual generation, and removing the previous auto-triggering logic.

### New Feature: Manual Metadata Generation
* [`src/app/context/notes-context.tsx`](diffhunk://#diff-dc5e990ffa76ec76c12bd369717bd856f1b435609f81082c94be48b9f78986cbR34-R36): Added `generateMetadataManually` and `isGeneratingMetadata` to the `NotesContextType` interface and integrated them into the `NotesProvider` to make these properties accessible throughout the application. [[1]](diffhunk://#diff-dc5e990ffa76ec76c12bd369717bd856f1b435609f81082c94be48b9f78986cbR34-R36) [[2]](diffhunk://#diff-dc5e990ffa76ec76c12bd369717bd856f1b435609f81082c94be48b9f78986cbR53-R54) [[3]](diffhunk://#diff-dc5e990ffa76ec76c12bd369717bd856f1b435609f81082c94be48b9f78986cbR197-R198)

* [`src/app/dashboard/notes/hooks/useSmartNotes.ts`](diffhunk://#diff-bb11ade9af71b63572099203d0bfe62f975a40d8715289a0efddba39af24f766R18-R20): Introduced `generateMetadataManually` as a new function for manually generating metadata and added `isGeneratingMetadata` to track the generation state. Removed the previous auto-triggering logic for metadata generation, making it a fully manual process. [[1]](diffhunk://#diff-bb11ade9af71b63572099203d0bfe62f975a40d8715289a0efddba39af24f766R18-R20) [[2]](diffhunk://#diff-bb11ade9af71b63572099203d0bfe62f975a40d8715289a0efddba39af24f766R30) [[3]](diffhunk://#diff-bb11ade9af71b63572099203d0bfe62f975a40d8715289a0efddba39af24f766L63-R78) [[4]](diffhunk://#diff-bb11ade9af71b63572099203d0bfe62f975a40d8715289a0efddba39af24f766L163-R172) [[5]](diffhunk://#diff-bb11ade9af71b63572099203d0bfe62f975a40d8715289a0efddba39af24f766L192-R201)

### UI Enhancements
* [`src/app/dashboard/notes/NoteArea.tsx`](diffhunk://#diff-83b220c5703b00a93216b02298eed57c2321c878f9183f8d45682a3911ecf23aR292-R312): Added a "Smart Title + Tags" button to the notes editor, which appears when the note content meets the minimum length requirement. The button uses the `generateMetadataManually` function and displays a loading spinner while metadata is being generated. [[1]](diffhunk://#diff-83b220c5703b00a93216b02298eed57c2321c878f9183f8d45682a3911ecf23aR292-R312) [[2]](diffhunk://#diff-83b220c5703b00a93216b02298eed57c2321c878f9183f8d45682a3911ecf23aR411-R433)

### Code Refinements
* [`src/app/dashboard/notes/NoteArea.tsx`](diffhunk://#diff-83b220c5703b00a93216b02298eed57c2321c878f9183f8d45682a3911ecf23aL337-R358): Simplified user ID retrieval by replacing `useAuth` with `getCurrentUserId`.
* [`src/app/dashboard/notes/hooks/useSmartNotes.ts`](diffhunk://#diff-bb11ade9af71b63572099203d0bfe62f975a40d8715289a0efddba39af24f766L97-R101): Improved error handling and user feedback for metadata generation, including toast notifications for success and failure scenarios. [[1]](diffhunk://#diff-bb11ade9af71b63572099203d0bfe62f975a40d8715289a0efddba39af24f766L97-R101) [[2]](diffhunk://#diff-bb11ade9af71b63572099203d0bfe62f975a40d8715289a0efddba39af24f766R120-L132)

These changes collectively enhance the user experience by providing a clear and controlled way to generate metadata for notes, while also simplifying the underlying logic and improving maintainability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "Smart Title + Tags" button to notes, allowing users to manually generate metadata for their notes when the content has at least 10 characters.
  * The button shows a loading spinner while metadata is being generated and is disabled during the process.
  * Improved error handling and user notifications during metadata generation.

* **Refactor**
  * Metadata generation is now triggered manually instead of automatically, giving users more control over when it occurs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->