### PR TITLE
Enhance moveQueuePostsToMain mutation to include media type for optimzed insights

### DIFF
--- a/convex/instagramMutations.ts
+++ b/convex/instagramMutations.ts
@@ -1182,6 +1182,7 @@ export const moveQueuePostsToMain = mutation({
         movedPosts.push({
           postId: queuedPost.postId,
           id: queuedPost.postId, // Alias for compatibility
+          mediaType: queuedPost.mediaType, // Include media type for optimized insights
           internalId: mainId,
         });
       }


### PR DESCRIPTION
- Added mediaType property to the movedPosts object in the moveQueuePostsToMain mutation, allowing for better tracking and analysis of post types during the queue management process.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured that media type information is included when moving queued posts, improving compatibility and insights processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->