### PR TITLE
Add informational prompts for Gmail and YouTube platform connections

### DIFF
--- a/src/app/settings/tabs/platform-connect/GmailPlatformCard.tsx
+++ b/src/app/settings/tabs/platform-connect/GmailPlatformCard.tsx
@@ -62,6 +62,15 @@ export function GmailPlatformCard({
           <Loader2 className="w-5 h-5 animate-spin" />
         </div>
       )}
+      
+      {!account && (
+        <div className="mb-3 px-3 py-2 bg-muted rounded-md border">
+          <p className="text-xs text-muted-foreground">
+            <span className="font-medium">Quick note:</span> Press "Advanced" then "Go to heycontent-web" to connect your Gmail.
+          </p>
+        </div>
+      )}
+      
       <div className="flex items-center gap-3 mb-2">
         <div className="w-12 h-12 rounded-lg bg-red-500 flex items-center justify-center">
           <Mail className="w-6 h-6 text-white" />

--- a/src/app/settings/tabs/platform-connect/YouTubePlatformCard.tsx
+++ b/src/app/settings/tabs/platform-connect/YouTubePlatformCard.tsx
@@ -61,6 +61,15 @@ export function YouTubePlatformCard({
           <Loader2 className="w-5 h-5 animate-spin" />
         </div>
       )}
+      
+      {!account && (
+        <div className="mb-3 px-3 py-2 bg-muted rounded-md border">
+          <p className="text-xs text-muted-foreground text-center">
+            Thanks to our growing community, YouTube connections are currently limited. Keep creating! We're working to expand access!
+          </p>
+        </div>
+      )}
+      
       <div className="flex items-center gap-3 mb-2">
         <div className="w-12 h-12 rounded-lg flex items-center justify-center">
           <YouTubeBrandIcon href="https://youtube.com/" className="w-8 h-8 text-white" />


### PR DESCRIPTION
- Introduced a quick note in GmailPlatformCard to guide users on connecting their Gmail account.
- Added a message in YouTubePlatformCard to inform users about current connection limitations and encourage continued content creation.

These updates aim to enhance user experience by providing helpful context and support during the platform connection process.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an informational note to the Gmail connection card with guidance for connecting a Gmail account when none is linked.
  * Added a message to the YouTube connection card explaining current limitations and thanking users when no account is connected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->