### PR TITLE
fix: Refactor subscription update logic to handle request body correctly

### DIFF
--- a/convex/http.ts
+++ b/convex/http.ts
@@ -1413,9 +1413,14 @@ app.post("/api/users/:id/stripe/subscription", async (c) => {
 app.patch("/api/stripe/subscriptions/:id", async (c) => {
   const ctx = c.env;
   const stripeSubscriptionId = c.req.param("id");
-  const data = await c.req.json();
+  const requestBody = await c.req.json();
   
   try {
+    // Extract the 'data' field from the request body to avoid double-wrapping
+    // The backend sends: {"data": {includedRequests: 100, ...}}
+    // We need to pass just the inner data object to the mutation
+    const data = requestBody.data || requestBody;
+    
     // Use the dedicated subscription actions module to handle the update
     const result = await ctx.runMutation(api.subscriptionActions.updateSubscriptionFromStripe, {
       stripeSubscriptionId,


### PR DESCRIPTION
This pull request makes a targeted improvement to the handling of Stripe subscription updates in the `convex/http.ts` API route. The main change is to correctly extract the relevant data from the incoming request body before passing it to the backend mutation, preventing issues with double-wrapped data objects.

**API request parsing improvement:**

* Updated the `/api/stripe/subscriptions/:id` PATCH handler to extract the `data` field from the request body if present, ensuring only the inner data object is passed to the backend mutation instead of a potentially double-wrapped object.