### PR TITLE
feat: Clean chat context from UI while preserving backend context (#612)

### DIFF
--- a/convex/chatMutations.ts
+++ b/convex/chatMutations.ts
@@ -11,6 +11,7 @@ export const createConversation = mutation({
         content: v.string(),
         role: v.union(v.literal("user"), v.literal("assistant")),
         timestamp: v.number(),
+        context: v.optional(v.string()),
       })),
     },
     handler: async (ctx, args) => {
@@ -35,9 +36,10 @@ args: {
     userId: v.string(),
     conversationId: v.id("conversations"),
     message: v.object({
-    content: v.string(),
-    role: v.union(v.literal("user"), v.literal("assistant")),
-    timestamp: v.number(),
+      content: v.string(),
+      role: v.union(v.literal("user"), v.literal("assistant")),
+      timestamp: v.number(),
+      context: v.optional(v.string()),
     }),
 },
 handler: async (ctx, args) => {

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -165,6 +165,8 @@ export default defineSchema({
       content: v.string(),
       role: v.string(),
       timestamp: v.optional(v.number()),
+      // Optional hidden context used during generation, never shown in UI
+      context: v.optional(v.string()),
     })),
     createdAt: v.number(),
     updatedAt: v.number(),

--- a/src/app/api/chat/conversation/[chatId]/route.ts
+++ b/src/app/api/chat/conversation/[chatId]/route.ts
@@ -25,10 +25,32 @@ async function cleanMessageContent(content: string, role: string, userId: string
     return content;
   }
 
-  // Check if the message starts with [Context] and remove everything up to the actual user message
-  const contextPattern = /^\[Context\][\s\S]*?\n\n/;
-  let cleanedContent = content.replace(contextPattern, '');
-  
+  let cleanedContent = content;
+
+  // Strategy 1: Extract after an explicit user label (case-insensitive), supporting multiple variants
+  const lower = cleanedContent.toLowerCase();
+  const labelVariants = [
+    'user message:',
+    'user question:',
+    "user's message:",
+    "user's question:",
+  ];
+  let bestIdx = -1;
+  let bestLabel = '';
+  for (const lbl of labelVariants) {
+    const idx = lower.lastIndexOf(lbl);
+    if (idx !== -1 && idx >= bestIdx) {
+      bestIdx = idx;
+      bestLabel = lbl;
+    }
+  }
+  if (bestIdx !== -1) {
+    cleanedContent = cleanedContent.slice(bestIdx + bestLabel.length).trimStart();
+  } else {
+    // Strategy 2: Remove any leading [Context ...] block up to the first double newline
+    cleanedContent = cleanedContent.replace(/^\[Context[^\]]*\][\s\S]*?\n\n/, '');
+  }
+
   // Extract content IDs and convert them to titles
   const contentIds = extractContentIds(cleanedContent);
   if (contentIds.length > 0) {
@@ -49,6 +71,12 @@ async function cleanMessageContent(content: string, role: string, userId: string
     }
   }
   
+  // Remove any trailing generic instruction blocks injected by backend prompts
+  cleanedContent = cleanedContent.replace(/\n+Please help[\s\S]*$/i, '');
+
+  // Remove leading markdown emphasis/bullets like "** " or "* " or "__ "
+  cleanedContent = cleanedContent.replace(/^\s*(\*{1,3}|_{1,3})\s+/, '');
+
   return cleanedContent.trim();
 }
 

--- a/src/app/api/chat/history/route.ts
+++ b/src/app/api/chat/history/route.ts
@@ -25,10 +25,32 @@ async function cleanMessageContent(content: string, role: string, userId: string
     return content;
   }
 
-  // Check if the message starts with [Context] and remove everything up to the actual user message
-  const contextPattern = /^\[Context\][\s\S]*?\n\n/;
-  let cleanedContent = content.replace(contextPattern, '');
-  
+  let cleanedContent = content;
+
+  // Strategy 1: Extract after an explicit user label (case-insensitive), supporting multiple variants
+  const lower = cleanedContent.toLowerCase();
+  const labelVariants = [
+    'user message:',
+    'user question:',
+    "user's message:",
+    "user's question:",
+  ];
+  let bestIdx = -1;
+  let bestLabel = '';
+  for (const lbl of labelVariants) {
+    const idx = lower.lastIndexOf(lbl);
+    if (idx !== -1 && idx >= bestIdx) {
+      bestIdx = idx;
+      bestLabel = lbl;
+    }
+  }
+  if (bestIdx !== -1) {
+    cleanedContent = cleanedContent.slice(bestIdx + bestLabel.length).trimStart();
+  } else {
+    // Strategy 2: Remove any leading [Context ...] block up to the first double newline
+    cleanedContent = cleanedContent.replace(/^\[Context[^\]]*\][\s\S]*?\n\n/, '');
+  }
+
   // Extract content IDs and convert them to titles
   const contentIds = extractContentIds(cleanedContent);
   if (contentIds.length > 0) {
@@ -37,7 +59,7 @@ async function cleanMessageContent(content: string, role: string, userId: string
         prefixedIds: contentIds,
         userId
       });
-      
+
       // Replace content IDs with titles
       cleanedContent = cleanedContent.replace(/@\[([^\]]+)\]@/g, (match, contentId) => {
         const title = titles[contentId];
@@ -48,7 +70,14 @@ async function cleanMessageContent(content: string, role: string, userId: string
       // If there's an error, keep the original content IDs
     }
   }
-  
+
+  // Remove any trailing generic instruction blocks injected by backend prompts
+  // e.g., "Please help them understand and work with this <platform> content ..."
+  cleanedContent = cleanedContent.replace(/\n+Please help[\s\S]*$/i, '');
+
+  // Remove leading markdown emphasis/bullets like "** " or "* " or "__ "
+  cleanedContent = cleanedContent.replace(/^\s*(\*{1,3}|_{1,3})\s+/, '');
+
   return cleanedContent.trim();
 }
 

--- a/src/app/api/chat/message/route.ts
+++ b/src/app/api/chat/message/route.ts
@@ -194,51 +194,6 @@ export async function POST(request: Request) {
         hasId: 'id' in item
       })));
 
-      // Create a context message with all linked content
-      const linkContextMessages = resolvedLinkContent.map((item: any) => {
-        let contentType = 'Content';
-        
-        // Map content types to human-readable labels
-        switch (item.type) {
-          case 'smart_note':
-            contentType = 'Smart Note';
-            break;
-          case 'youtube':
-            contentType = 'YouTube Video Analysis';
-            break;
-          case 'instagram':
-            contentType = 'Instagram Post Analysis';
-            break;
-          case 'gmail':
-            contentType = 'Gmail Thread';
-            break;
-          case 'insight':
-            contentType = 'AI Insight';
-            break;
-          case 'conversation':
-            contentType = 'Conversation';
-            break;
-          default:
-            contentType = item.type ? `${item.type.charAt(0).toUpperCase() + item.type.slice(1)}` : 'Content';
-        }
-        
-        // Debug: log the content to see what we're working with
-        console.log(`[${requestId}] Processing ${contentType} content:`, {
-          type: item.type,
-          title: item.title,
-          contentType: typeof item.content,
-          contentLength: item.content?.length || 0,
-          contentPreview: typeof item.content === 'string' ? item.content.substring(0, 200) : JSON.stringify(item.content).substring(0, 200)
-        });
-        
-        // Ensure content is a string
-        const contentString = typeof item.content === 'string' ? item.content : JSON.stringify(item.content);
-        
-        return `[${contentType}: ${item.title}]\n${contentString}`;
-      });
-
-      const linkContextText = linkContextMessages.join('\n\n');
-      
       // Replace link tokens in the user message with titles using the already resolved link content
       // Note: userMessageWithTitles is already declared globally above
       
@@ -361,7 +316,7 @@ export async function POST(request: Request) {
         }
       }
       
-      // Replace each link token with its title
+      // Replace each link token with its title in the echoed user message only
       userMessageWithTitles = userMessageWithTitles.replace(/@\[([^\]]+)\]@/g, (match, contentId) => {
         const title = contentIdToTitle.get(contentId);
         return title ? `[${title}]` : match;
@@ -372,21 +327,42 @@ export async function POST(request: Request) {
         replaced: userMessageWithTitles,
         contentIdToTitle: Object.fromEntries(contentIdToTitle)
       });
-      
-      // Inject the link content context into the query
-      const enhancedQuery = `[Context from linked content]\n\n${linkContextText}\n\n---\n\nUser message: ${userMessageWithTitles}`;
-      
-      console.log(`[${requestId}] Enhanced query with link content:`, {
-        originalLength: query.length,
-        enhancedLength: enhancedQuery.length,
-        linkContentCount: resolvedLinkContent.length,
-        userMessageWithTitles
+    }
+
+    // If we have resolved link content, also construct a human-readable context and inject it into the query
+    if (resolvedLinkContent && Array.isArray(resolvedLinkContent) && resolvedLinkContent.length > 0) {
+      const linkContextMessages = resolvedLinkContent.map((item: any) => {
+        let contentType = 'Content';
+        switch (item.type) {
+          case 'smart_note':
+            contentType = 'Smart Note';
+            break;
+          case 'youtube':
+            contentType = 'YouTube Video Analysis';
+            break;
+          case 'instagram':
+            contentType = 'Instagram Post Analysis';
+            break;
+          case 'gmail':
+            contentType = 'Gmail Thread';
+            break;
+          case 'insight':
+            contentType = 'AI Insight';
+            break;
+          case 'conversation':
+            contentType = 'Conversation';
+            break;
+          default:
+            contentType = item.type ? `${item.type.charAt(0).toUpperCase() + item.type.slice(1)}` : 'Content';
+        }
+        const contentString = typeof item.content === 'string' ? item.content : JSON.stringify(item.content);
+        return `[${contentType}: ${item.title}]\n${contentString}`;
       });
 
-      // Update the query with the enhanced version
+      const linkContextText = linkContextMessages.join('\n\n');
+      const enhancedQuery = `[Context from linked content]\n\n${linkContextText}\n\n---\n\nUser message: ${userMessageWithTitles}`;
       backendRequestBody.query = enhancedQuery;
     } else {
-      // If no link content, use the original query
       backendRequestBody.query = query;
     }
 

--- a/src/app/dashboard/chat/hooks/useChat.ts
+++ b/src/app/dashboard/chat/hooks/useChat.ts
@@ -100,11 +100,8 @@ export const useChat = (
     const isFirstMessage = !sessionId;
     const backendSessionId = isFirstMessage ? null : sessionId;
 
-    // Inject AI analysis into the query if enabled and available
-    let enhancedQuery = content;
-    if (includeAnalysisInQuery && contentContext?.analysis) {
-      enhancedQuery = `Context for user question:\n\n${contentContext.analysis}\n\n Make sure to address user question in your response\n\n---\n\nUser question: ${content}`;
-    }
+    // Do NOT inject analysis/context into the user message. We pass context separately.
+    const userQuery = content;
 
     console.log('🔗 useChat: Creating message with:', {
       content: content.substring(0, 100) + '...',
@@ -190,7 +187,7 @@ export const useChat = (
         } else {
           await addMessageToConversationMutation({
             userId: userId || '',
-            conversationId: sessionId,
+            conversationId: sessionId as any,
             message: {
               content: trimmedContent,
               role: 'user',
@@ -205,16 +202,16 @@ export const useChat = (
       // Send the enhanced query to the backend (with analysis injected if enabled)
       // Now includes vector search with status updates
       console.log('🔗 useChat: Sending to backend:', {
-        enhancedQuery: enhancedQuery.substring(0, 100) + '...',
-        hasContentLinks: enhancedQuery.includes('@[')
+        userQueryPreview: userQuery.substring(0, 100) + '...',
+        hasContentLinks: userQuery.includes('@[')
       })
       
       const data = await sendChatMessage(
-        enhancedQuery, 
+        userQuery, 
         isFirstMessage, 
         backendSessionId, 
         contentContext, 
-        includeAnalysisInQuery && !!contentContext?.analysis,
+        false,
         handleStatusUpdate, // Pass status update callback
         useContextSearch // Pass context search toggle
       );


### PR DESCRIPTION
- Add optional context field to conversation messages schema
- Strip injected context blocks from chat history display
- Remove backend boilerplate instructions from user messages
- Preserve full context for backend via separate fields
- Convert @[platform:id]@ tokens to readable titles in UI
- Stop client-side analysis injection into message body

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Smarter cleaning of user messages: detects user labels, trims leading context blocks, removes boilerplate and markdown clutter.
  - Linked content is summarized into contextual snippets (Notes, Insights, Conversations, YouTube, Instagram, Gmail), and titles replace ID tokens in messages.
  - Gmail links can fetch full thread content for richer context.

- Refactor
  - Sends raw user input to the backend without auto-injected analysis to avoid unintended alterations.
  - Messages now support an optional, non-visible context field.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->