### PR TITLE
feat: Add free tier subscription option and related functionality (#614)

### DIFF
--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -48,7 +48,8 @@ export default defineSchema({
         v.literal("monthly_basic"),
         v.literal("monthly_pro"),
         v.literal("yearly_basic"),
-        v.literal("yearly_pro")
+        v.literal("yearly_pro"),
+        v.literal("monthly_free")
       ),
       priceId: v.string(),
       meteredPriceId: v.optional(v.string()),

--- a/convex/subscriptionQueries.ts
+++ b/convex/subscriptionQueries.ts
@@ -59,7 +59,8 @@ export const saveSubscription = mutation({
       v.literal("monthly_basic"),
       v.literal("monthly_pro"),
       v.literal("yearly_basic"),
-      v.literal("yearly_pro")
+      v.literal("yearly_pro"),
+      v.literal("monthly_free")
     ),
     priceId: v.string(),
     meteredPriceId: v.optional(v.string()),

--- a/src/app/api/subscription/free-tier/route.ts
+++ b/src/app/api/subscription/free-tier/route.ts
@@ -1,0 +1,88 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { extractAuthInfo } from '@/app/lib/api-helpers-server';
+import { createFreeTierSubscription } from '@/app/lib/subscription-api';
+
+export async function POST(request: NextRequest) {
+  const startTime = Date.now();
+  const requestId = Math.random().toString(36).substring(7);
+
+  console.log(`[${requestId}] Free tier subscription request started`, {
+    timestamp: new Date().toISOString(),
+    method: request.method,
+    url: request.url
+  });
+
+  try {
+    // Auth
+    const authHeader = request.headers.get('Authorization');
+    const { apiKey, userId: authUserId } = extractAuthInfo(authHeader);
+
+    if (!apiKey) {
+      console.warn(`[${requestId}] Authentication failed: No Authorization header or invalid format`);
+      return NextResponse.json({ error: 'We need to verify your account to continue. Please sign in to unlock your creative potential!' }, { status: 401 });
+    }
+
+    // Parse request body
+    const body = await request.json();
+    const userId = body.userId || authUserId;
+    const email = body.email || '';
+    const name = body.name || '';
+
+    // Validate required fields
+    if (!userId || !email || !name) {
+      console.error(`[${requestId}] Invalid free tier request: missing required fields`);
+      return NextResponse.json(
+        { error: 'A few details are missing to get you started. Please check your information and try again!' },
+        { status: 400 }
+      );
+    }
+
+    // Call API utility to create free tier subscription
+    try {
+      const result = await createFreeTierSubscription(
+        apiKey,
+        userId,
+        email,
+        name
+      );
+
+      // Success
+      console.log(`[${requestId}] Free tier subscription created successfully`, {
+        timestamp: new Date().toISOString(),
+        userId,
+        customerId: result.data?.customer_id,
+        subscriptionId: result.data?.subscription_id
+      });
+
+      return NextResponse.json({
+        success: true,
+        message: 'Free tier subscription created successfully',
+        data: result.data
+      });
+    } catch (apiError) {
+      console.error(`[${requestId}] Free tier subscription creation failed`, {
+        error: apiError instanceof Error ? apiError.message : 'Unknown API error'
+      });
+      
+      return NextResponse.json(
+        { error: apiError instanceof Error ? 
+          apiError.message : 
+          'We hit a snag while setting up your free tier. Our team is on it! Try again in a moment.' },
+        { status: 400 }
+      );
+    }
+  } catch (error) {
+    console.error(`[${requestId}] Free tier subscription request failed`, {
+      timestamp: new Date().toISOString(),
+      error: error instanceof Error ? error.message : 'Unknown error'
+    });
+    return NextResponse.json(
+      { error: 'We\'re having trouble processing your free tier subscription right now. Don\'t worry, your creative work is safe! Please try again in a few minutes.' },
+      { status: 500 }
+    );
+  } finally {
+    console.log(`[${requestId}] Free tier subscription request finished`, {
+      duration: Date.now() - startTime
+    });
+  }
+}

--- a/src/app/auth/_components/register-screen.tsx
+++ b/src/app/auth/_components/register-screen.tsx
@@ -63,21 +63,46 @@ const RegisterScreen: React.FC<RegisterScreenProps> = ({ onSuccess }) => {
   };
 
   const handleUpgradeClose = () => {
-    // Prevent accidental closing of the payment modal
-    // We'll keep this empty to ensure users complete the payment flow
-    // The modal will close automatically after successful payment
+    // Allow users to skip payment and access free tier
+    setStep('chat');
+    // Redirect to dashboard with a welcome parameter to trigger the onboarding message
+    router.push("/dashboard/chat?welcome=true");
+  };
+
+  const handleSelectPlan = (planId: string) => {
+    if (planId === 'free') {
+      // Free tier selected - redirect to dashboard
+      setStep('chat');
+      router.push("/dashboard/chat?welcome=true");
+    } else {
+      // Paid plan selected - continue to waitlist
+      setStep('waitlist');
+    }
   };
 
   return (
     <div className="min-h-screen flex items-center justify-center bg-gradient-to-b from-background/80 via-muted/20 to-background/80 p-4">
       <div className="w-full max-w-md">
         {step === 'payment' && (
-          <UpgradeModal
-            open={true}
-            onClose={handleUpgradeClose}
-            onSelectPlan={() => setStep('waitlist')}
-            context="registration"
-          />
+          <div className="space-y-4">
+            <UpgradeModal
+              open={true}
+              onClose={handleUpgradeClose}
+              onSelectPlan={handleSelectPlan}
+              context="registration"
+            />
+            <div className="text-center">
+              <p className="text-muted-foreground mb-2 text-sm">
+                Want to try HeyContent first?
+              </p>
+              <button
+                className="text-blue-600 hover:text-blue-700 underline text-sm"
+                onClick={handleUpgradeClose}
+              >
+                Skip for now - Start with free tier
+              </button>
+            </div>
+          </div>
         )}
         
         {step === 'register' && !registrationSuccess && (

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -42,7 +42,7 @@ export default function DashboardLayout({
     isSubscribed, 
     isLoading: isSubscriptionLoading, 
     error: subscriptionError 
-  } = useSubscriptionCheck(isPublicPath ? 'free' : 'basic');
+  } = useSubscriptionCheck(isPublicPath ? 'free' : 'free');
 
   // Monitor API key validity (only when authenticated)
   useApiKeyMonitor(); // 🔒 ENABLED: Provides immediate logout when logged in elsewhere

--- a/src/app/hooks/useSubscriptionCheck.ts
+++ b/src/app/hooks/useSubscriptionCheck.ts
@@ -4,8 +4,8 @@ import { useQuery } from 'convex/react';
 import { api } from '@/../convex/_generated/api';
 
 type SubscriptionStatus = {
-  status: 'active' | 'past_due' | 'canceled' | 'unpaid' | 'incomplete' | 'incomplete_expired' | 'dev' | 'tester' | 'trialing' | 'paused' | 'deleted' | 'unknown' | null;
-  plan?: 'monthly_basic' | 'monthly_pro' | 'yearly_basic' | 'yearly_pro' | null;
+  status: 'active' | 'past_due' | 'canceled' | 'unpaid' | 'incomplete' | 'incomplete_expired' | 'dev' | 'tester' | 'trialing' | 'paused' | 'deleted' | 'unknown' | 'free' | null;
+  plan?: 'monthly_basic' | 'monthly_pro' | 'yearly_basic' | 'yearly_pro' | 'monthly_free' | null;
   currentPeriodEnd?: number;
   cancelAtPeriodEnd?: boolean;
   isSubscribed: boolean;
@@ -42,21 +42,16 @@ export function useSubscriptionCheck(requiredPlan: SubscriptionPlan = 'free') {
       }
       
       if (subscriptionData === null) {
-        // No subscription data - treat as not subscribed
-        const status = {
-          status: null,
-          isSubscribed: false
+        // No subscription data - treat as free tier user
+        const status: SubscriptionStatus = {
+          status: 'free',
+          isSubscribed: true,  // Free users are considered "subscribed" to the free tier
+          plan: 'monthly_free'
         };
         setSubscriptionStatus(status);
         
-        if (requiredPlan !== 'free') {
-          setIsSubscribed(false);
-          if (!window.location.pathname.startsWith('/dashboard/subscribe-tab/subscription')) {
-            window.location.href = '/dashboard/subscribe-tab/subscription';
-          }
-        } else {
-          setIsSubscribed(true);
-        }
+        // Free tier users can access basic features
+        setIsSubscribed(true);
         return;
       }
       
@@ -66,20 +61,31 @@ export function useSubscriptionCheck(requiredPlan: SubscriptionPlan = 'free') {
         plan: subscriptionData.plan || null,
         currentPeriodEnd: subscriptionData.currentPeriodEnd,
         cancelAtPeriodEnd: subscriptionData.cancelAtPeriodEnd,
-        isSubscribed: ['active', 'trialing', 'dev', 'tester'].includes(subscriptionData.status || ''),
+        isSubscribed: ['active', 'trialing', 'dev', 'tester', 'free'].includes(subscriptionData.status || ''),
         includedRequests: subscriptionData.includedRequests,
         usedRequests: subscriptionData.usedRequests
       };
       
       setSubscriptionStatus(status);
       
-      if (requiredPlan !== 'free' && !status.isSubscribed) {
-        setIsSubscribed(false);
+      // Check if user meets the required plan level
+      if (requiredPlan === 'free') {
+        // Free tier is always accessible
+        setIsSubscribed(true);
+      } else if (requiredPlan === 'basic') {
+        // Basic features require at least free tier
+        setIsSubscribed(status.isSubscribed);
+      } else if (requiredPlan === 'pro') {
+        // Pro features require pro subscription
+        const isProUser = status.plan?.includes('pro') || false;
+        setIsSubscribed(isProUser);
+      }
+      
+      // Only redirect if user doesn't meet the required plan level
+      if (!status.isSubscribed && requiredPlan !== 'free') {
         if (!window.location.pathname.startsWith('/dashboard/subscribe-tab/subscription')) {
           window.location.href = '/dashboard/subscribe-tab/subscription';
         }
-      } else {
-        setIsSubscribed(true);
       }
     } catch (err) {
       console.error('Error checking subscription:', err);

--- a/src/app/lib/subscription-api.ts
+++ b/src/app/lib/subscription-api.ts
@@ -450,6 +450,39 @@ export async function checkRateLimit(
 }
 
 /**
+ * Creates a free tier subscription for a user
+ * 
+ * @param apiKey - The API key for authentication
+ * @param userId - The user ID
+ * @param email - The user's email
+ * @param name - The user's name
+ * @returns The free tier subscription response
+ */
+export async function createFreeTierSubscription(
+  apiKey: string,
+  userId: string,
+  email: string,
+  name: string
+): Promise<any> {
+  const { response, data } = await callSubscriptionAPI(
+    '/subscription/free-tier',
+    'POST',
+    apiKey,
+    {
+      user_id: userId,
+      email: email,
+      name: name
+    }
+  );
+  
+  if (!response.ok) {
+    throw new Error(data?.error || 'Failed to create free tier subscription');
+  }
+  
+  return data;
+}
+
+/**
  * Creates a customer portal session for managing subscriptions
  * 
  * @param apiKey - The API key for authentication

--- a/src/app/settings/tabs/subscription/subscription-overview.tsx
+++ b/src/app/settings/tabs/subscription/subscription-overview.tsx
@@ -374,8 +374,8 @@ export default function SubscriptionOverview() {
 
   if (error) return <div className="p-8 text-center text-red-600">{error}</div>;
 
-  // If user doesn't have an active subscription, show the checkout form
-  if (!status?.is_subscribed) {
+  // If user doesn't have any subscription (including free), show the checkout form
+  if (!status || (!status.is_subscribed && !status.plan_type)) {
     return (
       <div className="flex flex-col items-center justify-center min-h-[300px] py-12 px-4 w-full">
         <div className="w-full max-w-4xl mx-auto">

--- a/src/app/settings/tabs/subscription/upgrade-modal.tsx
+++ b/src/app/settings/tabs/subscription/upgrade-modal.tsx
@@ -155,6 +155,58 @@ export default function UpgradeModal({
     if (!selectedPlanData) {
       return;
     }
+    
+    // Handle free tier - create subscription via API
+    if (planId === 'free') {
+      setLoading(true);
+      try {
+        const apiKey = await getApiKey();
+        if (!apiKey) {
+          throw new Error('No API key found. Please log in again.');
+        }
+        
+        // Call the free tier subscription endpoint
+        const response = await fetch('/api/subscription/free-tier', {
+          method: 'POST',
+          headers: {
+            'Authorization': `Bearer ${apiKey}`,
+            'Content-Type': 'application/json'
+          },
+          body: JSON.stringify({
+            userId: firebaseUser?.uid,
+            email: firebaseUser?.email || '',
+            name: firebaseUser?.displayName || ''
+          })
+        });
+        
+        if (!response.ok) {
+          const errorText = await response.text();
+          throw new Error(`Failed to create free subscription: ${response.status} ${errorText}`);
+        }
+        
+        const result = await response.json();
+        
+        if (result.success) {
+          // Free subscription created successfully
+          if (context === 'registration') {
+            onSelectPlan('free');
+          } else {
+            onClose();
+            // Refresh the page to show updated subscription status
+            window.location.reload();
+          }
+        } else {
+          throw new Error(result.error || 'Failed to create free subscription');
+        }
+      } catch (error) {
+        console.error('Error creating free subscription:', error);
+        // Handle error - could show a toast notification here
+      } finally {
+        setLoading(false);
+      }
+      return;
+    }
+    
     // Use the price_id from the selected interval plan
     const priceId = selectedPlanData.price_id;
     if (!priceId) {


### PR DESCRIPTION
- Introduced a new free tier subscription plan, allowing users to select it during registration and upgrade processes.
- Updated schema and subscription queries to include the new 'monthly_free' plan.
- Implemented API endpoint for creating free tier subscriptions, handling user authentication and input validation.
- Enhanced user interface components to support free tier selection and onboarding experience.
- Adjusted subscription checks to recognize free tier users and ensure appropriate access to features.

These changes aim to improve user onboarding and provide a no-cost entry point for new users.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced a Free tier subscription option, including a new API endpoint to create Free subscriptions.
  - Registration flow now lets users skip payment and start on the Free tier.
  - Upgrade modal supports selecting the Free plan and applies subscription changes immediately.

- Refactor
  - Updated subscription checks to recognize and allow Free tier access across the app.
  - Dashboard and access control logic simplified to treat Free as a valid subscribed state.
  - Settings page logic adjusted to better handle missing or Free plan statuses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->