### PR TITLE
Refactor SelfHubPage: Comment out unused components and simplify layout

### DIFF
--- a/src/app/dashboard/self-hub/page.tsx
+++ b/src/app/dashboard/self-hub/page.tsx
@@ -2,10 +2,10 @@
 
 import React, { useEffect, useState } from 'react';
 import { PersonaTab } from './PersonaTab';
-import { TimelineScroller } from '../timeline/_components';
-import { UsageHeatmap } from './UsageHeatmap';
+// import { TimelineScroller } from '../timeline/_components';
+// import { UsageHeatmap } from './UsageHeatmap';
 import { getCurrentUserId } from '@/app/lib/api-helpers';
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
+// import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 
 // Help system imports
 import { EnhancedHelpButton } from '@/components/ui/enhanced-help-button'
@@ -23,37 +23,39 @@ export default function SelfHubPage() {
 
   return (
     <div className="h-screen flex flex-col overflow-hidden">
-      <Tabs defaultValue="persona" className="h-full flex flex-col">
-        {/* Header with tabs */}
-        <div className="px-6 py-4 border-b bg-background">
-          <div className="flex items-center justify-between mb-4">
-            <div className="ml-12 md:ml-0">
-              <h1 className="text-2xl font-bold text-foreground">
-                Self
-              </h1>
-              <p className="text-sm text-muted-foreground">
-                Manage your persona and activity.
-              </p>
-            </div>
-            <div>
-              <EnhancedHelpButton 
-                onInteractiveTour={() => setInteractiveTourOpen(true)}
-              />
-            </div>
+      {/* Header */}
+      <div className="px-6 py-4 border-b bg-background">
+        <div className="flex items-center justify-between mb-4">
+          <div className="ml-12 md:ml-0">
+            <h1 className="text-2xl font-bold text-foreground">
+              Self
+            </h1>
+            <p className="text-sm text-muted-foreground">
+              Manage your persona and activity.
+            </p>
           </div>
-          <TabsList className="grid w-full grid-cols-3">
-            <TabsTrigger value="persona" data-persona-tab>Persona</TabsTrigger>
-            <TabsTrigger value="timeline" data-timeline-tab>Timeline</TabsTrigger>
-            <TabsTrigger value="usage" data-activity-tab>Activity</TabsTrigger>
-          </TabsList>
+          <div>
+            <EnhancedHelpButton 
+              onInteractiveTour={() => setInteractiveTourOpen(true)}
+            />
+          </div>
         </div>
+        {/* Commented out tabs */}
+        {/* <TabsList className="grid w-full grid-cols-3">
+          <TabsTrigger value="persona" data-persona-tab>Persona</TabsTrigger>
+          <TabsTrigger value="timeline" data-timeline-tab>Timeline</TabsTrigger>
+          <TabsTrigger value="usage" data-activity-tab>Activity</TabsTrigger>
+        </TabsList> */}
+      </div>
 
-        {/* Tab content - full height for timeline */}
-        <TabsContent value="persona" className="flex-1 overflow-auto p-6" data-persona-content>
-          <PersonaTab />
-        </TabsContent>
+      {/* Only PersonaTab content */}
+      <div className="flex-1 overflow-auto p-6" data-persona-content>
+        <PersonaTab />
+      </div>
+
+      {/* Commented out other tab contents */}
+      {/* <Tabs defaultValue="persona" className="h-full flex flex-col">
         <TabsContent value="timeline" className="flex-1 h-full overflow-hidden" data-timeline-content>
-          {/* Timeline Filters - Placeholder for tour */}
           <div data-timeline-filters className="absolute opacity-0 pointer-events-none -z-10 w-1 h-1">
             <p className="text-sm text-muted-foreground">Filter your content timeline by date, type, or performance.</p>
           </div>
@@ -63,12 +65,10 @@ export default function SelfHubPage() {
           {userId ? (
             <div className="space-y-6">
               <UsageHeatmap userId={userId} />
-              {/* Goals Section - Placeholder for tour */}
               <div data-goals-section className="absolute opacity-0 pointer-events-none -z-10 w-1 h-1">
                 <h3 className="text-lg font-semibold mb-4">Content Goals & Milestones</h3>
                 <p className="text-sm text-muted-foreground">Track your progress towards creator objectives.</p>
               </div>
-              {/* Performance Trends - Placeholder for tour */}
               <div data-performance-trends className="absolute opacity-0 pointer-events-none -z-10 w-1 h-1">
                 <h3 className="text-lg font-semibold mb-4">Performance Trends</h3>
                 <p className="text-sm text-muted-foreground">Analyze your content performance over time.</p>
@@ -80,9 +80,7 @@ export default function SelfHubPage() {
             </div>
           )}
         </TabsContent>
-      </Tabs>
-
-
+      </Tabs> */}
 
       {/* Interactive Tour */}
       <InteractiveTooltip


### PR DESCRIPTION
- Commented out imports and components related to TimelineScroller, UsageHeatmap, and Tabs to streamline the SelfHubPage.
- Simplified the layout by removing the Tabs component and retaining only the PersonaTab for a cleaner user interface.
- Added comments to clarify the rationale behind the changes, enhancing code maintainability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified the Self Hub to a single-pane layout with a streamlined header.
  * Removed tab navigation; Persona view is now the primary visible content.
  * Temporarily hid Timeline and Activity/Usage sections.
  * Kept interactive tour and help button available.
  * No changes to routes or external behavior beyond UI simplification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->