### PR TITLE
More/personafixes

### DIFF
--- a/src/app/dashboard/_components/dashboard-nav.tsx
+++ b/src/app/dashboard/_components/dashboard-nav.tsx
@@ -241,9 +241,6 @@ export const DashboardNav = memo(function DashboardNav() {
       case 'content-hub':
         // This tab is active for multiple, non-nested routes
         return pathname.startsWith('/dashboard/content') || pathname.startsWith('/dashboard/ai-insights');
-      case 'self-hub':
-        // This tab is active for all its sub-routes
-        return pathname.startsWith(item.href);
       case 'partnerships':
         // This tab is active for all its sub-routes
         return pathname.startsWith('/dashboard/partnerships');
@@ -256,30 +253,6 @@ export const DashboardNav = memo(function DashboardNav() {
         return false;
     }
   }, [pathname]);
-
-  // Memoize the self hub link
-  const selfHubLink = useMemo(() => (
-    <Link
-      href="/dashboard/self-hub"
-      onClick={() => setIsExpanded(false)}
-      className={`flex items-center transition-colors p-2 rounded-md ${
-        pathname.startsWith('/dashboard/self-hub')
-          ? 'bg-primary'
-          : 'hover:bg-muted/80'
-      }`}
-    >
-      <Users className={`w-6 h-6 ${
-        pathname.startsWith('/dashboard/self-hub')
-          ? 'text-white dark:text-black'
-          : 'text-foreground'
-      }`} />
-      {isExpanded && <span className={`ml-3 text-sm font-medium ${
-        pathname.startsWith('/dashboard/self-hub')
-          ? 'text-white dark:text-black'
-          : 'text-foreground'
-      }`}>Self</span>}
-    </Link>
-  ), [pathname, isExpanded, setIsExpanded]);
 
   // Memoize the settings link
   const settingsLink = useMemo(() => (
@@ -303,7 +276,9 @@ export const DashboardNav = memo(function DashboardNav() {
     <div className={`h-screen fixed top-0 left-0 bg-muted/20 shadow-lg flex flex-col justify-between transition-all duration-300 z-40 ${isExpanded ? 'w-64 translate-x-0' : 'w-64 -translate-x-full md:w-16 md:translate-x-0'}`}>
       <div>
         <div className={`flex items-center h-20 ${isExpanded ? 'px-4' : 'justify-center'}`}>
-          {selfHubLink}
+          <Link href="/" className="flex items-center">
+            <Logo disableLink />
+          </Link>
         </div>
 
         <div className="flex flex-col items-center gap-4 mt-8">

--- a/src/app/dashboard/chat/components/main_chat/ChatHeader.tsx
+++ b/src/app/dashboard/chat/components/main_chat/ChatHeader.tsx
@@ -1,10 +1,12 @@
 import React from 'react';
-import { MessageSquare } from 'lucide-react';
+import { MessageSquare, Users } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Logo } from '@/components/ui/logo';
 import { HelpIconButton } from '@/components/ui/help-icon-button';
 import { EnhancedHelpButton } from '@/components/ui/enhanced-help-button';
 import { ThemeToggle } from '@/components/theme-toggle';
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
 
 interface ChatHeaderProps {
   onNewChat?: () => void;
@@ -17,6 +19,8 @@ const ChatHeader: React.FC<ChatHeaderProps> = ({
   onShowHelp,
   onInteractiveTour
 }) => {
+  const pathname = usePathname();
+  
   return (
     <div className="flex-shrink-0 border-b border-border bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
       <div className="flex items-center justify-between px-4 py-3">
@@ -41,6 +45,19 @@ const ChatHeader: React.FC<ChatHeaderProps> = ({
           )}
           
           <ThemeToggle />
+          
+          {/* Self tab - positioned after theme toggle */}
+          <Link
+            href="/dashboard/self-hub"
+            className={`flex items-center gap-2 px-3 py-2 rounded-md transition-colors text-sm ${
+              pathname.startsWith('/dashboard/self-hub')
+                ? 'bg-primary text-primary-foreground'
+                : 'bg-background/80 hover:bg-background text-foreground border border-border'
+            }`}
+          >
+            <Users className="w-4 h-4" />
+            <span className="hidden sm:inline">Self</span>
+          </Link>
           
           {onInteractiveTour ? (
             <EnhancedHelpButton onInteractiveTour={onInteractiveTour} />

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -79,6 +79,7 @@ export default function DashboardLayout({
       >
         <Menu className="w-6 h-6" />
       </button>
+      
       <main className={`flex-1 overflow-y-auto overflow-x-hidden transition-all duration-300 md:ml-20 ${isExpanded ? 'ml-64 md:ml-64' : 'ml-0'}`}>
         {children}
       </main>

--- a/src/app/dashboard/notes/components/NotesGrid.tsx
+++ b/src/app/dashboard/notes/components/NotesGrid.tsx
@@ -4,13 +4,15 @@ import { NoteCard } from './cards/NoteCard';
 import { EmailCard } from './cards/EmailCard';
 import { ProjectCard } from './projects/ProjectCard';
 import { CreateProjectModal } from './projects/CreateProjectModal';
-import { Plus, Search, Folder, X } from 'lucide-react';
+import { Plus, Search, Folder, X, Users } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { useCreateNote } from '../hooks/useCreateNote';
 import { useProjects } from '../hooks/useProjects';
 import { useNotes } from '@/app/context/notes-context';
 import { useAuth } from '@/app/context/auth-context';
 import { getPopularTags } from '../utils/tag-utils';
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
 import {
   DndContext,
   DragEndEvent,
@@ -85,6 +87,7 @@ export function NotesGrid({
   const { createNote, isCreating: isCreatingNote } = useCreateNote();
   const { setActiveNoteId } = useNotes();
   const { firebaseUser } = useAuth();
+  const pathname = usePathname();
   
   // Projects functionality
   const { 
@@ -201,7 +204,7 @@ export function NotesGrid({
         console.error('Failed to add note to project:', error);
       }
     }
-    
+
     // Handle dropping note on "create project" zone
     if (noteData?.type === 'note' && over.id === 'create-project-zone') {
       const note = noteData.note as Note;
@@ -210,77 +213,70 @@ export function NotesGrid({
     }
   };
 
-  // Note type configurations with colors - matching exact schema types
-  const noteTypes = [
-    { key: 'all', label: 'All Items', color: 'bg-gray-500' },
-    { key: 'projects', label: 'Projects', color: 'bg-blue-500' },
-    { key: 'task_checklist', label: 'To-Do List', color: 'bg-yellow-500' },
-    { key: 'collaboration_note', label: 'Collaboration', color: 'bg-green-500' },
-    { key: 'reflection_journal', label: 'Journal', color: 'bg-blue-500' },
-    { key: 'idea_bank', label: 'Idea Bank', color: 'bg-red-500' },
-    { key: 'content_script', label: 'Content/Script', color: 'bg-purple-500' },
-    { key: 'analytics_insight', label: 'Analytics/Insights', color: 'bg-pink-500' },
-    { key: 'email_draft', label: 'Emails', color: 'bg-orange-500' },
-  ] as const;
+  // Filter notes based on search term, type filter, and tag filter
+  const filteredNotes = useMemo(() => {
+    let filtered = notes;
 
-  // Determine what to show based on filter
-  const showingProjectsOnly = selectedTypeFilter === 'projects';
-  const showingAll = selectedTypeFilter === 'all';
-  
-  // ✨ MAIN CHANGE: Filter notes to exclude those that belong to ANY project
-  const notesInProjects = useMemo(() => {
-    const noteIds = new Set<string>();
-    projects.forEach(project => {
-      project.noteIds?.forEach(noteId => noteIds.add(noteId));
-    });
-    return noteIds;
-  }, [projects]);
-
-  // Filter notes based on search, type filter, tag filter, and project membership
-  const filteredNotes = showingProjectsOnly ? [] : notes.filter(note => {
-    // ✨ DEDUPLICATION: Exclude notes that belong to any project
-    if (notesInProjects.has(String(note._id))) {
-      return false;
+    // Apply search filter
+    if (searchTerm) {
+      const searchLower = searchTerm.toLowerCase();
+      filtered = filtered.filter(note => 
+        note.title?.toLowerCase().includes(searchLower) ||
+        note.content?.toLowerCase().includes(searchLower) ||
+        note.tags?.some(tag => tag.toLowerCase().includes(searchLower))
+      );
     }
 
-    const matchesSearch = searchTerm === '' || 
-      note.title.toLowerCase().includes(searchTerm.toLowerCase()) ||
-      note.content?.toLowerCase().includes(searchTerm.toLowerCase());
+    // Apply type filter
+    if (selectedTypeFilter !== 'all') {
+      filtered = filtered.filter(note => note.type === selectedTypeFilter);
+    }
 
-    const matchesTypeFilter = selectedTypeFilter === 'all' || note.type === selectedTypeFilter;
+    // Apply tag filter
+    if (selectedTagFilter) {
+      filtered = filtered.filter(note => 
+        note.tags?.includes(selectedTagFilter)
+      );
+    }
 
-    const matchesTagFilter = !selectedTagFilter || 
-      note.tags?.some(tag => tag.toLowerCase() === selectedTagFilter.toLowerCase());
+    return filtered;
+  }, [notes, searchTerm, selectedTypeFilter, selectedTagFilter]);
 
-    return matchesSearch && matchesTypeFilter && matchesTagFilter;
-  });
-  
-  // Filter projects based on search - show in 'all' view and 'projects' view
-  const filteredProjects = (showingAll || showingProjectsOnly) ? projects.filter(project => {
-    const matchesSearch = searchTerm === '' || 
-      project.name.toLowerCase().includes(searchTerm.toLowerCase()) ||
-      project.description?.toLowerCase().includes(searchTerm.toLowerCase());
-    
-    return matchesSearch;
-  }) : [];
+  // Filter projects based on search term
+  const filteredProjects = useMemo(() => {
+    if (selectedTypeFilter !== 'all' && selectedTypeFilter !== 'projects') {
+      return [];
+    }
 
-  // Sort notes by importance and recency (most recently edited first)
-  const sortedNotes = [...filteredNotes].sort((a, b) => {
-    // First priority: Important (favorite) notes come first
-    if (a.important && !b.important) return -1;
-    if (!a.important && b.important) return 1;
-    
-    // Second priority: Within each group (important/non-important), 
-    // sort by most recently updated first (descending order)
-    const aTime = a.updatedAt || a._creationTime || 0;
-    const bTime = b.updatedAt || b._creationTime || 0;
-    return bTime - aTime;
-  });
-  
-  // Sort projects by recency
-  const sortedProjects = [...filteredProjects].sort((a, b) => {
-    return b.updatedAt - a.updatedAt;
-  });
+    let filtered = projects;
+
+    // Apply search filter
+    if (searchTerm) {
+      const searchLower = searchTerm.toLowerCase();
+      filtered = filtered.filter(project => 
+        project.name?.toLowerCase().includes(searchLower) ||
+        project.description?.toLowerCase().includes(searchLower)
+      );
+    }
+
+    return filtered;
+  }, [projects, searchTerm, selectedTypeFilter]);
+
+  // Combine notes and projects for display
+  const allItems = [...filteredNotes, ...filteredProjects];
+  const totalItems = allItems.length;
+
+  // Determine what we're showing
+  const showingAll = selectedTypeFilter === 'all';
+  const showingProjectsOnly = selectedTypeFilter === 'projects';
+
+  // Note types for filter buttons
+  const noteTypes = [
+    { key: 'all', label: 'All', color: 'bg-gray-400' },
+    { key: 'idea_bank', label: 'Ideas', color: 'bg-yellow-400' },
+    { key: 'content_script', label: 'Content', color: 'bg-blue-400' },
+    { key: 'projects', label: 'Projects', color: 'bg-purple-400' },
+  ];
 
   // Helper function to render the appropriate card component
   const renderNoteCard = (note: Note) => {
@@ -311,21 +307,6 @@ export function NotesGrid({
     );
   };
 
-  // Combined items for mixed view (when showing 'all')
-  const combinedItems = showingAll ? [
-    ...sortedProjects.map(project => ({ type: 'project', item: project, timestamp: project.updatedAt })),
-    ...sortedNotes.map(note => ({ type: 'note', item: note, timestamp: note.updatedAt || note._creationTime || 0 }))
-  ].sort((a, b) => {
-    // Projects get slight priority in mixed view, then by timestamp
-    if (a.type === 'project' && b.type === 'note') return -1;
-    if (a.type === 'note' && b.type === 'project') return 1;
-    return b.timestamp - a.timestamp;
-  }) : [];
-
-  const totalItems = showingAll ? combinedItems.length : 
-                   showingProjectsOnly ? sortedProjects.length : 
-                   sortedNotes.length;
-
   return (
     <DndContext
       sensors={sensors}
@@ -342,11 +323,25 @@ export function NotesGrid({
               Your intelligent note-taking workspace
             </p>
           </div>
-          {helpButton && (
-            <div>
-              {helpButton}
-            </div>
-          )}
+          <div className="flex items-center gap-2">
+            {/* Self tab */}
+            <Link
+              href="/dashboard/self-hub"
+              className={`flex items-center gap-2 px-3 py-2 rounded-md transition-colors text-sm ${
+                pathname.startsWith('/dashboard/self-hub')
+                  ? 'bg-primary text-primary-foreground'
+                  : 'bg-background/80 hover:bg-background text-foreground border border-border'
+              }`}
+            >
+              <Users className="w-4 h-4" />
+              <span className="hidden sm:inline">Self</span>
+            </Link>
+            {helpButton && (
+              <div>
+                {helpButton}
+              </div>
+            )}
+          </div>
         </div>
 
         {/* Prominent Search Bar */}
@@ -427,10 +422,14 @@ export function NotesGrid({
             <h3 className="text-lg font-semibold text-foreground mb-2">
               {searchTerm || (selectedTypeFilter !== 'all' && selectedTypeFilter !== 'projects') || selectedTagFilter
                 ? `No ${showingProjectsOnly ? 'projects' : showingAll ? 'items' : 'notes'} found` 
-                : `No ${showingProjectsOnly ? 'projects' : showingAll ? 'items' : 'notes'} yet`
+                : showingProjectsOnly 
+                ? 'No projects yet'
+                : showingAll
+                ? 'No notes or projects yet'
+                : 'No notes yet'
               }
             </h3>
-            <p className="text-muted-foreground mb-6 max-w-md">
+            <p className="text-muted-foreground mb-4 max-w-md">
               {searchTerm || (selectedTypeFilter !== 'all' && selectedTypeFilter !== 'projects') || selectedTagFilter
                 ? "Try adjusting your search, filters, or tags to find what you're looking for."
                 : showingProjectsOnly 
@@ -463,22 +462,22 @@ export function NotesGrid({
             <div className="px-4">
               <div className="columns-1 sm:columns-2 lg:columns-3 xl:columns-4 2xl:columns-5 gap-4 pb-6">
                 {showingAll 
-                  ? combinedItems.map((item) => (
-                      <div key={`${item.type}-${String(item.item._id)}`} className="break-inside-avoid mb-4 w-full">
-                        {item.type === 'project' ? (
+                  ? allItems.map((item) => (
+                      <div key={`${'type' in item ? item.type : 'project'}-${String(item._id)}`} className="break-inside-avoid mb-4 w-full">
+                        {'type' in item && item.type === 'project' ? (
                           <ProjectCard
-                            project={item.item as any}
+                            project={item as any}
                             onEdit={handleEditProject}
-                            onDelete={() => deleteProject(item.item._id as any)}
+                            onDelete={() => deleteProject(item._id as any)}
                             dragOverProject={dragOverProject}
                           />
                         ) : (
-                          renderNoteCard(item.item as Note)
+                          renderNoteCard(item as Note)
                         )}
                       </div>
                     ))
                   : showingProjectsOnly 
-                  ? sortedProjects.map((project) => (
+                  ? filteredProjects.map((project) => (
                       <div key={String(project._id)} className="break-inside-avoid mb-4 w-full">
                         <ProjectCard
                           project={project}
@@ -488,7 +487,7 @@ export function NotesGrid({
                         />
                       </div>
                     ))
-                  : sortedNotes.map((note) => (
+                  : filteredNotes.map((note) => (
                       <div key={String(note._id)} className="break-inside-avoid mb-4 w-full">
                         {renderNoteCard(note)}
                       </div>

--- a/src/app/dashboard/self-hub/PersonaTab.tsx
+++ b/src/app/dashboard/self-hub/PersonaTab.tsx
@@ -86,7 +86,12 @@ const PersonaTabSkeleton = React.memo(() => (
 
 PersonaTabSkeleton.displayName = 'PersonaTabSkeleton';
 
-export const PersonaTab = React.memo(() => {
+interface PersonaTabProps {
+  isEditMode?: boolean;
+  onEditModeChange?: (isEditMode: boolean) => void;
+}
+
+export const PersonaTab = React.memo(({ isEditMode = false, onEditModeChange }: PersonaTabProps) => {
   // Always declare hooks at the very top before any conditional return
   const [modalOpen, setModalOpen] = React.useState(true);
   console.log('[PERSONA TAB] Component rendering started at:', new Date().toISOString());
@@ -143,7 +148,7 @@ export const PersonaTab = React.memo(() => {
     }
   }, [firebaseUser?.uid, isPersonaInitialized, lastFetchedUserId, currentPersona, isCacheValid, initializePersonaData, refreshPersonaData, convex]);
 
-  // Memoize the new persona handler with eligibility check
+  // Memoized fetch function to prevent recreation
   const handleNewPersona = React.useCallback(() => {
     if (eligibility?.canGenerate) {
       console.log('[PERSONA TAB] New persona button clicked');
@@ -258,6 +263,8 @@ export const PersonaTab = React.memo(() => {
             <Suspense fallback={<PersonaTabSkeleton />}>
               <PersonaUpdateManager 
                 userId={firebaseUser?.uid} 
+                isEditMode={isEditMode}
+                onEditModeChange={onEditModeChange}
                 renderNewPersonaButton={() => (
                   <Button
                     onClick={handleNewPersona}
@@ -285,6 +292,8 @@ export const PersonaTab = React.memo(() => {
       <Suspense fallback={<PersonaTabSkeleton />}>
         <PersonaUpdateManager 
           userId={firebaseUser?.uid} 
+          isEditMode={isEditMode}
+          onEditModeChange={onEditModeChange}
           renderNewPersonaButton={() => (
             <Button
               onClick={handleNewPersona}

--- a/src/app/dashboard/self-hub/page.tsx
+++ b/src/app/dashboard/self-hub/page.tsx
@@ -2,21 +2,73 @@
 
 import React, { useEffect, useState } from 'react';
 import { PersonaTab } from './PersonaTab';
-// import { TimelineScroller } from '../timeline/_components';
-// import { UsageHeatmap } from './UsageHeatmap';
+import { Button } from '@/components/ui/button';
+import { Edit2, Trash2 } from 'lucide-react';
 import { getCurrentUserId } from '@/app/lib/api-helpers';
-// import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
-
-
+import { useOptimizedPersonaManager } from '@/store/persona-store';
 
 export default function SelfHubPage() {
   const [userId, setUserId] = useState<string | undefined>();
-
+  const [isEditMode, setIsEditMode] = useState(false);
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
 
   useEffect(() => {
     const currentUserId = getCurrentUserId();
     setUserId(currentUserId || undefined);
   }, []);
+
+  // Get persona data and actions
+  const {
+    currentPersona,
+    allPersonas,
+    updatePersona,
+    deleteCurrentPersonaAndSelectNext,
+  } = useOptimizedPersonaManager(userId || '');
+
+  const handleEdit = () => {
+    setIsEditMode(true);
+  };
+
+  const handleCancel = () => {
+    setIsEditMode(false);
+  };
+
+  const handleSave = async () => {
+    // This will be handled by the PersonaEditForm component
+    setIsEditMode(false);
+  };
+
+  const handleDeleteClick = () => {
+    if (allPersonas.length > 1) {
+      setShowDeleteConfirm(true);
+    }
+  };
+
+  const handleDeleteConfirm = async () => {
+    if (!currentPersona) return;
+    
+    setIsDeleting(true);
+    try {
+      const success = await deleteCurrentPersonaAndSelectNext();
+      if (success) {
+        setShowDeleteConfirm(false);
+        setIsEditMode(false);
+      }
+    } catch (error) {
+      console.error('Error deleting persona:', error);
+    } finally {
+      setIsDeleting(false);
+    }
+  };
+
+  const handleDeleteCancel = () => {
+    setShowDeleteConfirm(false);
+  };
+
+  const handleUpdatePersona = () => {
+    window.location.href = '/dashboard/chat?ask=' + encodeURIComponent('hey content update persona');
+  };
 
   return (
     <div className="h-screen flex flex-col overflow-hidden">
@@ -31,51 +83,99 @@ export default function SelfHubPage() {
               A private space to explore how you think and what works for you.
             </p>
           </div>
-
+          
+          {/* Action Buttons */}
+          <div className="flex items-center gap-3">
+            <Button
+              variant={isEditMode ? 'default' : 'outline'}
+              size="sm"
+              onClick={isEditMode ? handleSave : handleEdit}
+              className="min-h-[40px]"
+            >
+              <Edit2 className="w-4 h-4 mr-2" />
+              {isEditMode ? 'Save' : 'Edit'}
+            </Button>
+            {isEditMode && (
+              <Button 
+                variant="ghost" 
+                size="sm" 
+                onClick={handleCancel}
+                className="min-h-[40px]"
+              >
+                Cancel
+              </Button>
+            )}
+            {!isEditMode && allPersonas.length > 1 && (
+              <Button 
+                variant="outline" 
+                size="sm"
+                onClick={handleDeleteClick}
+                className="min-h-[40px] text-destructive border-destructive hover:bg-destructive/10"
+              >
+                <Trash2 className="w-4 h-4 mr-2" />
+                Delete
+              </Button>
+            )}
+            {!isEditMode && (
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={handleUpdatePersona}
+                className="min-h-[40px]"
+              >
+                Update Persona
+              </Button>
+            )}
+          </div>
         </div>
-        {/* Commented out tabs */}
-        {/* <TabsList className="grid w-full grid-cols-3">
-          <TabsTrigger value="persona" data-persona-tab>Persona</TabsTrigger>
-          <TabsTrigger value="timeline" data-timeline-tab>Timeline</TabsTrigger>
-          <TabsTrigger value="usage" data-activity-tab>Activity</TabsTrigger>
-        </TabsList> */}
       </div>
 
       {/* Only PersonaTab content */}
       <div className="flex-1 overflow-auto p-6" data-persona-content>
-        <PersonaTab />
+        <PersonaTab isEditMode={isEditMode} onEditModeChange={setIsEditMode} />
       </div>
 
-      {/* Commented out other tab contents */}
-      {/* <Tabs defaultValue="persona" className="h-full flex flex-col">
-        <TabsContent value="timeline" className="flex-1 h-full overflow-hidden" data-timeline-content>
-          <div data-timeline-filters className="absolute opacity-0 pointer-events-none -z-10 w-1 h-1">
-            <p className="text-sm text-muted-foreground">Filter your content timeline by date, type, or performance.</p>
+      {/* Delete Confirmation Modal */}
+      {showDeleteConfirm && (
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
+          <div className="bg-background rounded-lg max-w-md w-full p-6 shadow-lg">
+            <h3 className="text-lg font-semibold mb-4 text-foreground">
+              Delete Current Persona?
+            </h3>
+            <p className="text-muted-foreground mb-6">
+              This will permanently delete this understanding of how you work and automatically switch to your most recent self-reflection. This action cannot be undone.
+            </p>
+            <div className="flex gap-3 justify-end">
+              <Button 
+                variant="ghost" 
+                onClick={handleDeleteCancel}
+                disabled={isDeleting}
+                className="min-h-[44px]"
+              >
+                Cancel
+              </Button>
+              <Button 
+                variant="destructive" 
+                onClick={handleDeleteConfirm}
+                disabled={isDeleting}
+                className="min-h-[44px]"
+              >
+                {isDeleting ? (
+                  <>
+                    <div className="w-4 h-4 border-2 border-white border-t-transparent rounded-full animate-spin mr-2" />
+                    Deleting...
+                  </>
+                ) : (
+                  <>
+                    <Trash2 className="w-4 h-4 mr-2" />
+                    Delete Persona
+                  </>
+                )}
+              </Button>
+            </div>
           </div>
-          <TimelineScroller />
-        </TabsContent>
-        <TabsContent value="usage" className="flex-1 overflow-auto p-6" data-activity-content>
-          {userId ? (
-            <div className="space-y-6">
-              <UsageHeatmap userId={userId} />
-              <div data-goals-section className="absolute opacity-0 pointer-events-none -z-10 w-1 h-1">
-                <h3 className="text-lg font-semibold mb-4">Content Goals & Milestones</h3>
-                <p className="text-sm text-muted-foreground">Track your progress towards creator objectives.</p>
-              </div>
-              <div data-performance-trends className="absolute opacity-0 pointer-events-none -z-10 w-1 h-1">
-                <h3 className="text-lg font-semibold mb-4">Performance Trends</h3>
-                <p className="text-sm text-muted-foreground">Analyze your content performance over time.</p>
-              </div>
-            </div>
-          ) : (
-            <div className="flex justify-center items-center min-h-[200px] px-4 rounded-lg border border-dashed">
-              <p className="text-gray-600 text-sm">Please sign in to view your activity.</p>
-            </div>
-          )}
-        </TabsContent>
-      </Tabs> */}
-
-
+        </div>
+      )}
     </div>
   );
 } 

--- a/src/app/settings/tabs/account/NewPersonaCard.tsx
+++ b/src/app/settings/tabs/account/NewPersonaCard.tsx
@@ -1,87 +1,110 @@
 import React from 'react';
 import { PersonaData } from '../../../dashboard/chat/types';
-import { Badge } from '@/components/ui/badge';
 
 interface NewPersonaCardProps {
   persona: PersonaData;
 }
 
-const Section: React.FC<{ title: string; description: string; children: React.ReactNode }> = ({ title, description, children }) => (
-  <div className="py-6 border-b border-border">
-    <div className="mb-4">
-      <h3 className="text-base font-semibold text-foreground">{title}</h3>
-      <p className="text-sm text-muted-foreground">{description}</p>
-    </div>
-    <div className="grid grid-cols-1 md:grid-cols-2 gap-x-8 gap-y-4">
-      {children}
-    </div>
-  </div>
-);
-
-const InfoItem: React.FC<{ label: string; value: string | string[] | undefined }> = ({ label, value }) => {
-  if (!value || (Array.isArray(value) && value.length === 0)) return null;
+const PersonaField: React.FC<{
+  label: string;
+  value: string | string[];
+  isArray?: boolean;
+}> = ({ label, value, isArray = false }) => {
+  if (!value || (Array.isArray(value) && value.length === 0)) {
+    return null;
+  }
 
   return (
-    <div>
-      <p className="text-xs font-medium text-muted-foreground uppercase tracking-wider dark:group-hover:text-accent group-hover:text-purple-500 transition-colors duration-300">{label}</p>
+    <div className="mb-8">
+      <h4 className="text-sm font-medium text-muted-foreground mb-3 uppercase tracking-wide">
+        {label}
+      </h4>
       {Array.isArray(value) ? (
-        <div className="flex flex-wrap gap-2 mt-2">
+        <div className="flex flex-wrap gap-2">
           {value.map((item, index) => (
-            <Badge 
-              key={index} 
-              variant="outline" 
-              className="font-normal border-border group-hover:text-purple-500 group-hover:border-purple-500/50 dark:group-hover:text-accent dark:group-hover:border-accent/50 transition-colors"
+            <span
+              key={index}
+              className="inline-block px-3 py-1.5 text-sm bg-muted/60 text-foreground rounded-full border border-border/50"
             >
               {item}
-            </Badge>
+            </span>
           ))}
         </div>
       ) : (
-        <p className="text-sm text-foreground/90 mt-1">{value}</p>
+        <p className="text-base leading-relaxed text-foreground whitespace-pre-wrap">
+          {value}
+        </p>
       )}
     </div>
   );
 };
 
-
 export const NewPersonaCard: React.FC<NewPersonaCardProps> = ({ persona }) => {
-  if (!persona) return null;
-
   return (
-    <div className="bg-card rounded-lg transition-all duration-300">
-      <div className="p-6">
-        <h2 className="text-2xl font-bold text-foreground transition-colors">{persona.current_name}</h2>
-        <p className="mt-2 text-base text-muted-foreground leading-relaxed">{persona.current_description}</p>
+    <div className="w-full">
+      {/* Header Section */}
+      <div className="mb-12 pb-8 border-b border-border/50">
+        <h1 className="text-3xl font-semibold text-foreground mb-4">
+          {persona.current_name}
+        </h1>
+        <p className="text-lg leading-relaxed text-muted-foreground">
+          {persona.current_description}
+        </p>
       </div>
 
-      <div className="px-6">
-        <Section title="How You Express Yourself" description="Your natural communication style and approach">
-          <InfoItem label="Experience Level" value={persona.experience_level} />
-          <InfoItem label="Formats You Gravitate To" value={persona.content_formats} />
-          <InfoItem label="Your Natural Tone" value={persona.content_tone} />
-          <InfoItem label="Your Voice" value={persona.content_voice} />
-          <InfoItem label="What Makes You Unique" value={persona.unique_value} />
-          <InfoItem label="Who You Connect With" value={persona.audience_type} />
-        </Section>
+      {/* Content Sections */}
+      <div className="space-y-16">
+        {/* How You Express Yourself */}
+        <section>
+          <h2 className="text-2xl font-medium text-foreground mb-8 pb-2 border-b border-border/30">
+            How You Express Yourself
+          </h2>
+          <div className="space-y-8">
+            <PersonaField label="Experience Level" value={persona.experience_level} />
+            <PersonaField label="Content Formats" value={persona.content_formats} isArray={true} />
+            <PersonaField label="Natural Tone" value={persona.content_tone} />
+            <PersonaField label="Your Voice" value={persona.content_voice} />
+            <PersonaField label="Unique Value" value={persona.unique_value} />
+            <PersonaField label="Audience Type" value={persona.audience_type} />
+          </div>
+        </section>
 
-        <Section title="How You're Growing" description="Where you see yourself heading and what matters to you">
-          <InfoItem label="Who You're Becoming" value={persona.future_name} />
-          <InfoItem label="Your Vision" value={persona.future_description} />
-          <InfoItem label="Impact You Want to Make" value={persona.desired_impact} />
-          <InfoItem label="What You're Working Toward" value={persona.goals} />
-        </Section>
+        {/* How You're Growing */}
+        <section>
+          <h2 className="text-2xl font-medium text-foreground mb-8 pb-2 border-b border-border/30">
+            How You're Growing
+          </h2>
+          <div className="space-y-8">
+            <PersonaField label="Who You're Becoming" value={persona.future_name} />
+            <PersonaField label="Your Vision" value={persona.future_description} />
+            <PersonaField label="Desired Impact" value={persona.desired_impact} />
+            <PersonaField label="Goals" value={persona.goals} isArray={true} />
+          </div>
+        </section>
 
-        <Section title="What You Return To" description="The themes and approaches that feel most natural to you">
-          <InfoItem label="What You Think About Most" value={persona.primary_topics} />
-          <InfoItem label="Other Things You Explore" value={persona.secondary_topics} />
-          <InfoItem label="How You Connect" value={persona.engagement_style} />
-          <InfoItem label="Your Core Themes" value={persona.content_pillars} />
-        </Section>
+        {/* What You Return To */}
+        <section>
+          <h2 className="text-2xl font-medium text-foreground mb-8 pb-2 border-b border-border/30">
+            What You Return To
+          </h2>
+          <div className="space-y-8">
+            <PersonaField label="Primary Topics" value={persona.primary_topics} isArray={true} />
+            <PersonaField label="Secondary Topics" value={persona.secondary_topics} isArray={true} />
+            <PersonaField label="Engagement Style" value={persona.engagement_style} />
+            <PersonaField label="Content Pillars" value={persona.content_pillars} isArray={true} />
+          </div>
+        </section>
 
-        <Section title="Your Personal Style" description="The patterns that make your communication uniquely yours">
-          <InfoItem label="How You Sound" value={persona.tone_descriptors} />
-          <InfoItem label="Your Approach" value={persona.style_descriptors} />
-        </Section>
+        {/* Your Personal Style */}
+        <section>
+          <h2 className="text-2xl font-medium text-foreground mb-8 pb-2 border-b border-border/30">
+            Your Personal Style
+          </h2>
+          <div className="space-y-8">
+            <PersonaField label="Tone Descriptors" value={persona.tone_descriptors} isArray={true} />
+            <PersonaField label="Style Descriptors" value={persona.style_descriptors} isArray={true} />
+          </div>
+        </section>
       </div>
     </div>
   );

--- a/src/app/settings/tabs/account/PersonaEditForm.tsx
+++ b/src/app/settings/tabs/account/PersonaEditForm.tsx
@@ -1,6 +1,5 @@
 import React, { useState, useEffect } from 'react';
 import { PersonaData } from '../../../dashboard/chat/types';
-import { Badge } from '@/components/ui/badge';
 import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
 import { Label } from '@/components/ui/label';
@@ -10,23 +9,11 @@ interface PersonaEditFormProps {
   onUpdate: (field: keyof PersonaData, value: string | string[]) => void;
 }
 
-const Section: React.FC<{ title: string; description: string; children: React.ReactNode }> = ({ title, description, children }) => (
-    <div className="py-6 border-b border-border last:border-b-0">
-        <div className="mb-4">
-            <h3 className="text-base font-semibold text-foreground">{title}</h3>
-            <p className="text-sm text-muted-foreground">{description}</p>
-        </div>
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-x-8 gap-y-6">
-            {children}
-        </div>
-    </div>
-);
-
-const EditableField: React.FC<{
+const EditField: React.FC<{
   label: string;
   value: string | string[];
   field: keyof PersonaData;
-  onUpdate: (field: keyof PersonaData, value: string) => void;
+  onUpdate: (field: keyof PersonaData, value: string | string[]) => void;
   isArray?: boolean;
 }> = ({ label, value, field, onUpdate, isArray = false }) => {
   const [inputValue, setInputValue] = useState(Array.isArray(value) ? value.join(', ') : value || '');
@@ -36,12 +23,18 @@ const EditableField: React.FC<{
   }, [value]);
 
   const handleBlur = () => {
-    onUpdate(field, inputValue);
+    if (isArray) {
+      // For array fields, split by comma and trim
+      const arrayValue = inputValue.split(',').map(item => item.trim()).filter(item => item.length > 0);
+      onUpdate(field, arrayValue);
+    } else {
+      onUpdate(field, inputValue);
+    }
   };
 
   return (
-    <div className="space-y-2">
-      <Label htmlFor={String(field)} className="text-xs font-medium text-muted-foreground uppercase tracking-wider">
+    <div className="mb-8">
+      <Label htmlFor={String(field)} className="text-sm font-medium text-muted-foreground mb-3 uppercase tracking-wide block">
         {label}
       </Label>
       <Input
@@ -50,13 +43,17 @@ const EditableField: React.FC<{
         onChange={(e) => setInputValue(e.target.value)}
         onBlur={handleBlur}
         placeholder={isArray ? 'Separate with commas' : `Enter ${label.toLowerCase()}`}
+        className="text-base h-12 px-4 border-border/50 focus:border-border transition-colors"
       />
       {isArray && Array.isArray(value) && value.length > 0 && (
-        <div className="flex flex-wrap gap-2 pt-2">
+        <div className="flex flex-wrap gap-2 mt-3">
           {value.map((item, index) => (
-            <Badge key={index} variant="outline" className="font-normal">
+            <span 
+              key={index} 
+              className="inline-block px-3 py-1.5 text-sm bg-muted/60 text-foreground rounded-full border border-border/50"
+            >
               {item}
-            </Badge>
+            </span>
           ))}
         </div>
       )}
@@ -64,108 +61,199 @@ const EditableField: React.FC<{
   );
 };
 
-const EditableTextarea: React.FC<{
+const EditTextarea: React.FC<{
   label: string;
   value: string;
   field: keyof PersonaData;
-  onUpdate: (field: keyof PersonaData, value: string) => void;
+  onUpdate: (field: keyof PersonaData, value: string | string[]) => void;
 }> = ({ label, value, field, onUpdate }) => {
-    const [textValue, setTextValue] = useState(value || '');
+  const [textValue, setTextValue] = useState(value || '');
 
-    useEffect(() => {
-        setTextValue(value || '');
-    }, [value]);
+  useEffect(() => {
+    setTextValue(value || '');
+  }, [value]);
 
-    const handleBlur = () => {
-        onUpdate(field, textValue);
-    };
+  const handleBlur = () => {
+    onUpdate(field, textValue);
+  };
 
-    return (
-        <div className="space-y-2">
-            <Label htmlFor={String(field)} className="text-xs font-medium text-muted-foreground uppercase tracking-wider">
-                {label}
-            </Label>
-            <Textarea
-                id={String(field)}
-                value={textValue}
-                onChange={(e) => setTextValue(e.target.value)}
-                onBlur={handleBlur}
-                placeholder={`Describe ${label.toLowerCase()}`}
-                rows={4}
-            />
-        </div>
-    );
+  return (
+    <div className="mb-8">
+      <Label htmlFor={String(field)} className="text-sm font-medium text-muted-foreground mb-3 uppercase tracking-wide block">
+        {label}
+      </Label>
+      <Textarea
+        id={String(field)}
+        value={textValue}
+        onChange={(e) => setTextValue(e.target.value)}
+        onBlur={handleBlur}
+        placeholder={`Describe ${label.toLowerCase()}`}
+        rows={4}
+        className="text-base px-4 py-3 border-border/50 focus:border-border transition-colors resize-none"
+      />
+    </div>
+  );
 };
 
 export const PersonaEditForm: React.FC<PersonaEditFormProps> = ({ persona, onUpdate }) => {
-  const handleUpdate = (field: keyof PersonaData, value: string | string[]) => {
-    onUpdate(field, value);
-  };
-
-  const handleArrayUpdate = (field: keyof PersonaData, value: string) => {
-    const items = value.split(',').map(item => item.trim()).filter(Boolean);
-    onUpdate(field, items);
-  };
-  
   return (
-    <div className="bg-card rounded-lg">
-      <div className="p-6">
-        <div className="space-y-2 mb-6">
-            <Label htmlFor="current_name" className="text-xs font-medium text-muted-foreground uppercase tracking-wider">Persona Name</Label>
-            <Input
-                id="current_name"
-                value={persona.current_name}
-                onChange={(e) => handleUpdate('current_name', e.target.value)}
-                className="text-2xl font-bold h-auto p-0 border-none focus-visible:ring-0"
-                placeholder="Persona Name"
-            />
-        </div>
-        <div className="space-y-2">
-            <Label htmlFor="current_description" className="text-xs font-medium text-muted-foreground uppercase tracking-wider">Description</Label>
-            <Textarea
-                id="current_description"
-                value={persona.current_description}
-                onChange={(e) => handleUpdate('current_description', e.target.value)}
-                placeholder="Describe your persona..."
-                className="text-base border-none p-0 focus-visible:ring-0"
-            />
-        </div>
+    <div className="w-full">
+      {/* Header Section */}
+      <div className="mb-12 pb-8 border-b border-border/50">
+        <EditField
+          label="Current Name"
+          value={persona.current_name}
+          field="current_name"
+          onUpdate={onUpdate}
+        />
+        <EditTextarea
+          label="Current Description"
+          value={persona.current_description}
+          field="current_description"
+          onUpdate={onUpdate}
+        />
       </div>
 
-      <div className="px-6">
-        <Section title="Creator Identity" description="Current style and audience focus">
-          <EditableField label="Experience Level" value={persona.experience_level} field="experience_level" onUpdate={handleUpdate} />
-          <EditableField label="Content Formats" value={persona.content_formats} field="content_formats" onUpdate={handleArrayUpdate} isArray />
-          <EditableField label="Tone" value={persona.content_tone} field="content_tone" onUpdate={handleUpdate} />
-          <EditableField label="Voice" value={persona.content_voice} field="content_voice" onUpdate={handleUpdate} />
-          <div className="md:col-span-2">
-            <EditableTextarea label="Unique Value" value={persona.unique_value} field="unique_value" onUpdate={handleUpdate} />
+      {/* Content Sections */}
+      <div className="space-y-16">
+        {/* How You Express Yourself */}
+        <section>
+          <h2 className="text-2xl font-medium text-foreground mb-8 pb-2 border-b border-border/30">
+            How You Express Yourself
+          </h2>
+          <div className="space-y-8">
+            <EditField 
+              label="Experience Level" 
+              value={persona.experience_level}
+              field="experience_level"
+              onUpdate={onUpdate}
+            />
+            <EditField 
+              label="Content Formats" 
+              value={persona.content_formats}
+              field="content_formats"
+              onUpdate={onUpdate}
+              isArray={true}
+            />
+            <EditField 
+              label="Natural Tone" 
+              value={persona.content_tone}
+              field="content_tone"
+              onUpdate={onUpdate}
+            />
+            <EditField 
+              label="Your Voice" 
+              value={persona.content_voice}
+              field="content_voice"
+              onUpdate={onUpdate}
+            />
+            <EditField 
+              label="Unique Value" 
+              value={persona.unique_value}
+              field="unique_value"
+              onUpdate={onUpdate}
+            />
+            <EditField 
+              label="Audience Type" 
+              value={persona.audience_type}
+              field="audience_type"
+              onUpdate={onUpdate}
+            />
           </div>
-          <EditableField label="Audience Type" value={persona.audience_type} field="audience_type" onUpdate={handleUpdate} />
-        </Section>
+        </section>
 
-        <Section title="Future Vision" description="Where your content journey is heading">
-          <EditableField label="Future Persona" value={persona.future_name} field="future_name" onUpdate={handleUpdate} />
-          <div className="md:col-span-2">
-            <EditableTextarea label="Vision Description" value={persona.future_description} field="future_description" onUpdate={handleUpdate} />
+        {/* How You're Growing */}
+        <section>
+          <h2 className="text-2xl font-medium text-foreground mb-8 pb-2 border-b border-border/30">
+            How You're Growing
+          </h2>
+          <div className="space-y-8">
+            <EditField 
+              label="Who You're Becoming" 
+              value={persona.future_name}
+              field="future_name"
+              onUpdate={onUpdate}
+            />
+            <EditTextarea 
+              label="Your Vision" 
+              value={persona.future_description}
+              field="future_description"
+              onUpdate={onUpdate}
+            />
+            <EditTextarea 
+              label="Desired Impact" 
+              value={persona.desired_impact}
+              field="desired_impact"
+              onUpdate={onUpdate}
+            />
+            <EditField 
+              label="Goals" 
+              value={persona.goals}
+              field="goals"
+              onUpdate={onUpdate}
+              isArray={true}
+            />
           </div>
-          <div className="md:col-span-2">
-            <EditableTextarea label="Desired Impact" value={persona.desired_impact} field="desired_impact" onUpdate={handleUpdate} />
+        </section>
+
+        {/* What You Return To */}
+        <section>
+          <h2 className="text-2xl font-medium text-foreground mb-8 pb-2 border-b border-border/30">
+            What You Return To
+          </h2>
+          <div className="space-y-8">
+            <EditField 
+              label="Primary Topics" 
+              value={persona.primary_topics}
+              field="primary_topics"
+              onUpdate={onUpdate}
+              isArray={true}
+            />
+            <EditField 
+              label="Secondary Topics" 
+              value={persona.secondary_topics}
+              field="secondary_topics"
+              onUpdate={onUpdate}
+              isArray={true}
+            />
+            <EditField 
+              label="Engagement Style" 
+              value={persona.engagement_style}
+              field="engagement_style"
+              onUpdate={onUpdate}
+            />
+            <EditField 
+              label="Content Pillars" 
+              value={persona.content_pillars}
+              field="content_pillars"
+              onUpdate={onUpdate}
+              isArray={true}
+            />
           </div>
-          <EditableField label="Goals" value={persona.goals} field="goals" onUpdate={handleArrayUpdate} isArray />
-        </Section>
+        </section>
 
-        <Section title="Content Strategy" description="Topic approach and audience engagement">
-          <EditableField label="Primary Topics" value={persona.primary_topics} field="primary_topics" onUpdate={handleArrayUpdate} isArray />
-          <EditableField label="Secondary Topics" value={persona.secondary_topics} field="secondary_topics" onUpdate={handleArrayUpdate} isArray />
-          <EditableField label="Engagement Style" value={persona.engagement_style} field="engagement_style" onUpdate={handleUpdate} />
-          <EditableField label="Content Pillars" value={persona.content_pillars} field="content_pillars" onUpdate={handleArrayUpdate} isArray />
-        </Section>
-
-        <Section title="Creative Signature" description="The unique fingerprint of your content">
-          <EditableField label="Tone Descriptors" value={persona.tone_descriptors} field="tone_descriptors" onUpdate={handleArrayUpdate} isArray />
-          <EditableField label="Style Descriptors" value={persona.style_descriptors} field="style_descriptors" onUpdate={handleArrayUpdate} isArray />
-        </Section>
+        {/* Your Personal Style */}
+        <section>
+          <h2 className="text-2xl font-medium text-foreground mb-8 pb-2 border-b border-border/30">
+            Your Personal Style
+          </h2>
+          <div className="space-y-8">
+            <EditField 
+              label="Tone Descriptors" 
+              value={persona.tone_descriptors}
+              field="tone_descriptors"
+              onUpdate={onUpdate}
+              isArray={true}
+            />
+            <EditField 
+              label="Style Descriptors" 
+              value={persona.style_descriptors}
+              field="style_descriptors"
+              onUpdate={onUpdate}
+              isArray={true}
+            />
+          </div>
+        </section>
       </div>
     </div>
   );

--- a/src/app/settings/tabs/account/PersonaUpdateManager.tsx
+++ b/src/app/settings/tabs/account/PersonaUpdateManager.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
 import { useOptimizedPersonaManager } from '@/store/persona-store';
@@ -10,9 +10,16 @@ import { NewPersonaCard } from './NewPersonaCard';
 interface PersonaUpdateManagerProps {
   userId: string;
   renderNewPersonaButton?: () => React.ReactNode;
+  isEditMode?: boolean;
+  onEditModeChange?: (isEditMode: boolean) => void;
 }
 
-export const PersonaUpdateManager: React.FC<PersonaUpdateManagerProps> = ({ userId, renderNewPersonaButton }) => {
+export const PersonaUpdateManager: React.FC<PersonaUpdateManagerProps> = ({ 
+  userId, 
+  renderNewPersonaButton,
+  isEditMode = false,
+  onEditModeChange
+}) => {
   const renderStartTime = performance.now();
   
   const {
@@ -34,47 +41,41 @@ export const PersonaUpdateManager: React.FC<PersonaUpdateManagerProps> = ({ user
     timestamp: new Date().toISOString()
   });
 
-  const [isEditMode, setIsEditMode] = useState(false);
-  const [editedPersona, setEditedPersona] = useState<PersonaData | null>(null);
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
 
+  // Use external edit mode state if provided, otherwise use internal state
+  const [internalEditMode, setInternalEditMode] = useState(false);
+  const actualEditMode = onEditModeChange ? isEditMode : internalEditMode;
+  const setActualEditMode = onEditModeChange ? onEditModeChange : setInternalEditMode;
+
+  const [editedPersona, setEditedPersona] = useState(currentPersona);
+
+  useEffect(() => {
+    setEditedPersona(currentPersona);
+  }, [currentPersona]);
+
   const handleEdit = () => {
-    if (currentPersona) {
-      setEditedPersona({ ...currentPersona });
-      setIsEditMode(true);
-    }
+    setActualEditMode(true);
   };
 
   const handleCancel = () => {
-    setEditedPersona(null);
-    setIsEditMode(false);
+    setActualEditMode(false);
+    setEditedPersona(currentPersona);
   };
 
   const handleSave = async () => {
-    if (!editedPersona || !currentPersona) return;
-
-    const changes: Partial<PersonaData> = {};
-    Object.keys(editedPersona).forEach(key => {
-      const editedKey = key as keyof PersonaData;
-      if (JSON.stringify(editedPersona[editedKey]) !== JSON.stringify(currentPersona[editedKey])) {
-        changes[editedKey] = editedPersona[editedKey];
+    if (editedPersona && currentPersona) {
+      try {
+        await updatePersona(editedPersona);
+        setActualEditMode(false);
+      } catch (error) {
+        console.error('Error updating persona:', error);
       }
-    });
-
-    if (Object.keys(changes).length === 0) {
-      setEditedPersona(null);
-      setIsEditMode(false);
-      return;
     }
-
-    await updatePersona(changes);
-    setEditedPersona(null);
-    setIsEditMode(false);
   };
 
   const handleDeleteClick = () => {
-    // Only allow deletion if there are multiple personas
     if (allPersonas.length > 1) {
       setShowDeleteConfirm(true);
     }
@@ -88,12 +89,7 @@ export const PersonaUpdateManager: React.FC<PersonaUpdateManagerProps> = ({ user
       const success = await deleteCurrentPersonaAndSelectNext();
       if (success) {
         setShowDeleteConfirm(false);
-        // Reset edit mode if it was active
-        setIsEditMode(false);
-        setEditedPersona(null);
-      } else {
-        // Handle error - could show a toast or error message
-        console.error('Failed to delete persona');
+        setActualEditMode(false);
       }
     } catch (error) {
       console.error('Error deleting persona:', error);
@@ -106,11 +102,24 @@ export const PersonaUpdateManager: React.FC<PersonaUpdateManagerProps> = ({ user
     setShowDeleteConfirm(false);
   };
 
-
-
-  const updateField = (field: keyof PersonaData, value: string | string[]) => {
-    if (!editedPersona) return;
-    setEditedPersona({ ...editedPersona, [field]: value });
+  const updateField = (field: keyof typeof editedPersona, value: string | string[]) => {
+    if (editedPersona) {
+      // Handle array fields properly
+      let processedValue = value;
+      if (typeof value === 'string') {
+        // Check if this field should be an array
+        const arrayFields = ['content_formats', 'primary_topics', 'secondary_topics', 'content_pillars', 'tone_descriptors', 'style_descriptors'];
+        if (arrayFields.includes(field as string)) {
+          // Split by comma and trim whitespace
+          processedValue = value.split(',').map(item => item.trim()).filter(item => item.length > 0);
+        }
+      }
+      
+      setEditedPersona({
+        ...editedPersona,
+        [field]: processedValue
+      });
+    }
   };
 
   if (isLoading) {
@@ -153,79 +162,27 @@ export const PersonaUpdateManager: React.FC<PersonaUpdateManagerProps> = ({ user
     );
   }
 
-  if (!hasPersona) {
+  if (!currentPersona) {
     return (
-      <div className="text-center py-12 px-4 space-y-6">
-        <div className="w-12 h-12 bg-muted rounded-lg mx-auto flex items-center justify-center">
-          <Plus className="w-6 h-6 text-muted-foreground" />
-        </div>
-        <div className="space-y-4">
-          <div>
-            <p className="font-medium text-foreground text-lg">Let's get to know you</p>
-            <p className="text-sm text-muted-foreground mt-2 leading-relaxed max-w-sm mx-auto">
-              Help HeyContext understand how you think and work best
-            </p>
-          </div>
-          <Button 
-            onClick={() => window.location.href = '/dashboard/chat?ask=hey%20content%20persona'}
-            className="w-full sm:w-auto min-h-[48px] px-6 bg-purple-500 hover:bg-purple-600 dark:bg-accent dark:hover:bg-accent/90 text-white"
-          >
-            Start Getting to Know Each Other
-          </Button>
+      <div className="flex flex-col items-center justify-center min-h-[400px] text-center">
+        <div className="max-w-md">
+          <h3 className="text-lg font-semibold mb-2 text-foreground">
+            No Persona Found
+          </h3>
+          <p className="text-muted-foreground mb-6">
+            Create your first persona to get started with personalized insights.
+          </p>
+          {renderNewPersonaButton && renderNewPersonaButton()}
         </div>
       </div>
     );
   }
 
   return (
-    <div className="space-y-6">
-      {/* Current Persona */}
+    <div>
+      {/* Persona Content */}
       <div>
-        <div className="flex flex-col space-y-4 sm:flex-row sm:items-start sm:justify-between sm:space-y-0 mb-6">
-          <div className="space-y-1">
-            <h2 className="text-lg font-semibold text-purple-600 dark:text-accent">Your Persona</h2>
-            <p className="text-sm text-muted-foreground">What HeyContext has learned about your thinking patterns and preferences</p>
-          </div>
-          <div className="flex flex-col sm:flex-row items-stretch sm:items-center gap-3 sm:gap-2">
-            <Button
-              variant={isEditMode ? 'default' : 'outline'}
-              size="sm"
-              onClick={isEditMode ? handleSave : handleEdit}
-              className={`min-h-[44px] w-full sm:w-auto transition-colors ${
-                isEditMode 
-                  ? 'bg-purple-500 hover:bg-purple-600 dark:bg-accent dark:hover:bg-accent/90 text-white' 
-                  : 'text-purple-500 border-purple-500 hover:bg-purple-50 dark:text-accent dark:border-accent dark:hover:bg-accent/10'
-              }`}
-            >
-              <Edit2 className="w-4 h-4 mr-2" />
-              {isEditMode ? 'Save' : 'Edit'}
-            </Button>
-            {isEditMode && (
-              <Button 
-                variant="ghost" 
-                size="sm" 
-                onClick={handleCancel}
-                className="min-h-[44px] w-full sm:w-auto text-muted-foreground hover:text-foreground hover:bg-muted"
-              >
-                Cancel
-              </Button>
-            )}
-            {!isEditMode && allPersonas.length > 1 && (
-              <Button 
-                variant="outline" 
-                size="sm"
-                onClick={handleDeleteClick}
-                className="min-h-[44px] w-full sm:w-auto text-red-500 border-red-500 hover:bg-red-50 dark:text-red-400 dark:border-red-400 dark:hover:bg-red-400/10"
-              >
-                <Trash2 className="w-4 h-4 mr-2" />
-                Delete
-              </Button>
-            )}
-            {!isEditMode && renderNewPersonaButton && renderNewPersonaButton()}
-          </div>
-        </div>
-
-        {isEditMode ? (
+        {actualEditMode ? (
           <PersonaEditForm persona={editedPersona!} onUpdate={updateField} />
         ) : (
           <NewPersonaCard persona={currentPersona!} />
@@ -255,7 +212,7 @@ export const PersonaUpdateManager: React.FC<PersonaUpdateManagerProps> = ({ user
                 variant="destructive" 
                 onClick={handleDeleteConfirm}
                 disabled={isDeleting}
-                className="min-h-[44px] bg-red-500 hover:bg-red-600"
+                className="min-h-[44px]"
               >
                 {isDeleting ? (
                   <>

--- a/src/components/ui/agents-showcase.tsx
+++ b/src/components/ui/agents-showcase.tsx
@@ -121,36 +121,7 @@ const conversation: ConversationMessage[] = [
   }
 ]
 
-const commandPaletteCommands: DisplayOption[] = [
-  {
-    id: 'analyze',
-    label: 'Analyze this conversation',
-    icon: <MessageSquare className="w-4 h-4" />,
-    action: () => {},
-    category: 'AI Actions'
-  },
-  {
-    id: 'summarize',
-    label: 'Summarize key points',
-    icon: <FileText className="w-4 h-4" />,
-    action: () => {},
-    category: 'AI Actions'
-  },
-  {
-    id: 'save-note',
-    label: 'Save as Smart Note',
-    icon: <Plus className="w-4 h-4" />,
-    action: () => {},
-    category: 'Notes'
-  },
-  {
-    id: 'expand',
-    label: 'Expand on this idea',
-    icon: <ChevronRight className="w-4 h-4" />,
-    action: () => {},
-    category: 'AI Actions'
-  }
-]
+
 
 function SmartSearchSources({ sources: sourceIds }: { sources?: string[] }) {
   if (!sourceIds || sourceIds.length === 0) return null
@@ -184,7 +155,10 @@ function SmartSearchSources({ sources: sourceIds }: { sources?: string[] }) {
   )
 }
 
-function SuggestionChips({ suggestions }: { suggestions?: Array<{ id: string; text: string; type: 'followup' | 'action' }> }) {
+function SuggestionChips({ suggestions, onSuggestionClick }: { 
+  suggestions?: Array<{ id: string; text: string; type: 'followup' | 'action' }>
+  onSuggestionClick?: (suggestion: string) => void
+}) {
   if (!suggestions || suggestions.length === 0) return null
 
   return (
@@ -192,6 +166,7 @@ function SuggestionChips({ suggestions }: { suggestions?: Array<{ id: string; te
       {suggestions.map((suggestion) => (
         <button
           key={suggestion.id}
+          onClick={() => onSuggestionClick?.(suggestion.text)}
           className="inline-flex items-center gap-2 bg-slate-100/80 dark:bg-slate-800/80 hover:bg-slate-200/80 dark:hover:bg-slate-700/80 text-slate-700 dark:text-slate-300 text-sm px-3 py-1.5 rounded-full transition-colors duration-200"
         >
           {suggestion.type === 'action' ? (
@@ -249,38 +224,62 @@ function InlineCommandPalette({ isOpen, onClose }: { isOpen: boolean; onClose: (
           onChange={(e) => setUserInput(e.target.value)}
           placeholder="Ask AI to analyze, summarize, or expand..."
           className="w-full px-3 py-2 text-sm bg-muted/50 border border-border rounded-md focus:outline-none focus:ring-2 focus:ring-purple-500/20 focus:border-purple-500"
+          disabled
         />
       </div>
 
       {/* Commands */}
       <div className="max-h-80 overflow-y-auto">
         <div className="py-2">
-          {commandPaletteCommands.map((option, index) => {
-            const isSelected = selectedIndex === index
-            
-            return (
+          <div className="px-4 py-2">
+            <h3 className="text-xs font-medium text-muted-foreground uppercase tracking-wide mb-2">
+              AI Actions
+            </h3>
+            <div className="space-y-0.5">
               <button
-                key={option.id}
-                onClick={option.action}
-                className={`w-full flex items-center gap-3 px-4 py-2 text-left transition-all duration-200 ${
-                  isSelected
-                    ? 'bg-purple-500/10 text-purple-600 dark:text-yellow-400' 
-                    : 'hover:bg-muted/50 text-foreground'
-                }`}
+                className="w-full flex items-center gap-3 px-3 py-2 text-left transition-all duration-200 opacity-50 cursor-not-allowed"
+                disabled
               >
                 <div className="flex-shrink-0 text-muted-foreground">
-                  {option.icon}
+                  <MessageSquare className="w-4 h-4" />
                 </div>
-                <span className="text-sm font-medium">
-                  {option.label}
-                </span>
-                {isSelected && (
-                  <ArrowRight className="w-3 h-3 ml-auto text-purple-600 dark:text-yellow-400" />
-                )}
+                <span className="text-sm font-medium">Analyze this conversation</span>
               </button>
-            )
-          })}
+              <button
+                className="w-full flex items-center gap-3 px-3 py-2 text-left transition-all duration-200 opacity-50 cursor-not-allowed"
+                disabled
+              >
+                <div className="flex-shrink-0 text-muted-foreground">
+                  <FileText className="w-4 h-4" />
+                </div>
+                <span className="text-sm font-medium">Summarize key points</span>
+              </button>
+              <button
+                className="w-full flex items-center gap-3 px-3 py-2 text-left transition-all duration-200 opacity-50 cursor-not-allowed"
+                disabled
+              >
+                <div className="flex-shrink-0 text-muted-foreground">
+                  <Plus className="w-4 h-4" />
+                </div>
+                <span className="text-sm font-medium">Save as Smart Note</span>
+              </button>
+              <button
+                className="w-full flex items-center gap-3 px-3 py-2 text-left transition-all duration-200 opacity-50 cursor-not-allowed"
+                disabled
+              >
+                <div className="flex-shrink-0 text-muted-foreground">
+                  <ChevronRight className="w-4 h-4" />
+                </div>
+                <span className="text-sm font-medium">Expand on this idea</span>
+              </button>
+            </div>
+          </div>
         </div>
+      </div>
+
+      {/* Footer */}
+      <div className="px-4 py-2 border-t border-border text-xs text-muted-foreground/80">
+        Preview mode - AI features disabled
       </div>
     </motion.div>
   )
@@ -290,12 +289,14 @@ const MarkdownNotepad = forwardRef(function MarkdownNotepad({
   isOpen, 
   onClose, 
   width, 
-  style
+  style,
+  onOpenCommandPalette
 }: {
   isOpen: boolean
   onClose: () => void
   width: number
   style: React.CSSProperties
+  onOpenCommandPalette?: () => void
 }, ref) {
   const [content, setContent] = useState(`# Job Search Strategy
 
@@ -338,6 +339,19 @@ Based on our discussion about job searching and potential relocation, here are t
     getContent: () => content || '',
   }), [content]);
 
+  // Handle Command+K
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (isOpen && (e.metaKey || e.ctrlKey) && e.key === 'k') {
+        e.preventDefault()
+        onOpenCommandPalette?.()
+      }
+    }
+
+    document.addEventListener('keydown', handleKeyDown)
+    return () => document.removeEventListener('keydown', handleKeyDown)
+  }, [isOpen, onOpenCommandPalette])
+
   if (!isOpen) return null
 
   return (
@@ -359,6 +373,14 @@ Based on our discussion about job searching and potential relocation, here are t
         </div>
         
         <div className="flex items-center gap-1">
+          <button
+            onClick={onOpenCommandPalette}
+            className="p-2 text-slate-500 hover:text-slate-700 dark:hover:text-slate-300 rounded-md hover:bg-slate-100 dark:hover:bg-slate-800 transition-colors"
+            title="Open AI Assistant (⌘K)"
+          >
+            <Plus className="w-4 h-4" />
+          </button>
+          
           <button
             onClick={() => setContent('')}
             className="px-2 py-1 text-xs text-muted-foreground hover:text-foreground rounded-md transition-colors hover:bg-muted"
@@ -400,6 +422,7 @@ export function AgentsShowcase() {
   const [notepadOpen, setNotepadOpen] = useState(true) // Open by default
   const [commandPaletteOpen, setCommandPaletteOpen] = useState(false)
   const [notepadWidth, setNotepadWidth] = useState(400)
+  const [inputValue, setInputValue] = useState('')
   const notepadRef = useRef<{ hasUnsavedContent: () => boolean; clearContent: () => void; getContent: () => string }>(null)
   const { theme } = useTheme()
 
@@ -412,6 +435,10 @@ export function AgentsShowcase() {
     transform: notepadOpen ? 'translateX(0)' : 'translateX(100%)',
     transition: 'transform 0.3s ease-in-out'
   })
+
+  const handleSuggestionClick = (suggestion: string) => {
+    setInputValue(suggestion)
+  }
 
   return (
     <section className="py-40 bg-gradient-to-b from-white via-blue-50/20 to-white dark:from-slate-900 dark:via-blue-950/10 dark:to-slate-900 relative overflow-hidden">
@@ -446,13 +473,6 @@ export function AgentsShowcase() {
                 </div>
               </div>
               <div className="flex items-center gap-2">
-                <button
-                  onClick={() => setCommandPaletteOpen(true)}
-                  className="p-2 text-slate-500 hover:text-slate-700 dark:hover:text-slate-300 rounded-md hover:bg-slate-100 dark:hover:bg-slate-800 transition-colors"
-                  title="Open AI Assistant"
-                >
-                  <Plus className="w-4 h-4" />
-                </button>
                 <button
                   onClick={() => setNotepadOpen(!notepadOpen)}
                   className="p-2 text-slate-500 hover:text-slate-700 dark:hover:text-slate-300 rounded-md hover:bg-slate-100 dark:hover:bg-slate-800 transition-colors"
@@ -500,7 +520,7 @@ export function AgentsShowcase() {
                         </div>
 
                         {/* Suggestions */}
-                        <SuggestionChips suggestions={message.suggestions} />
+                        <SuggestionChips suggestions={message.suggestions} onSuggestionClick={handleSuggestionClick} />
                       </div>
                     ))}
                   </div>
@@ -510,15 +530,18 @@ export function AgentsShowcase() {
               {/* Input Area */}
               <div className="border-t border-slate-200 dark:border-slate-700 bg-background p-4">
                 <div className="max-w-4xl mx-auto">
-                  <div className="flex items-end gap-3">
+                  <div className="flex items-center gap-3">
                     <div className="flex-1 relative">
                       <textarea
+                        value={inputValue}
+                        onChange={(e) => setInputValue(e.target.value)}
                         placeholder="Message HeyContext..."
                         className="w-full px-4 py-3 text-sm bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-lg resize-none focus:outline-none focus:ring-2 focus:ring-purple-500/20 focus:border-purple-500"
                         rows={1}
+                        style={{ height: '48px', lineHeight: '1.2' }}
                       />
                     </div>
-                    <button className="p-3 bg-purple-500 hover:bg-purple-600 text-white rounded-lg transition-colors" aria-label="Send message">
+                    <button className="flex-shrink-0 h-12 w-12 bg-purple-500 hover:bg-purple-600 text-white rounded-lg transition-colors flex items-center justify-center" aria-label="Send message">
                       <Send className="w-4 h-4" />
                     </button>
                   </div>
@@ -534,6 +557,7 @@ export function AgentsShowcase() {
             onClose={() => setNotepadOpen(false)}
             width={notepadWidth}
             style={getNotepadStyle()}
+            onOpenCommandPalette={() => setCommandPaletteOpen(true)}
           />
         </div>
 


### PR DESCRIPTION
This pull request primarily refactors navigation and filtering logic for dashboard components, improves the NotesGrid filtering and display, and enhances the visibility of the "Self" tab across multiple dashboard views. The most significant changes include removal of redundant navigation logic for the "Self" tab in the sidebar, addition of the "Self" tab to the header areas of both the chat and notes dashboards, and a major simplification and improvement to the notes and projects filtering in `NotesGrid`. There are also minor improvements to the `PersonaTab` props and rendering.

**Navigation and UI consistency:**

* Removed the dedicated "Self" tab logic from the dashboard sidebar navigation (`DashboardNav`), and replaced the sidebar's top link with the application logo for a cleaner look. The "Self" tab is now present in dashboard headers instead. [[1]](diffhunk://#diff-f2f9770671713859127faf1629389861adf31d076b2b3613bc46b5f061ede243L244-L246) [[2]](diffhunk://#diff-f2f9770671713859127faf1629389861adf31d076b2b3613bc46b5f061ede243L260-L283) [[3]](diffhunk://#diff-f2f9770671713859127faf1629389861adf31d076b2b3613bc46b5f061ede243L306-R281)
* Added a "Self" tab button (with icon) to the chat header (`ChatHeader.tsx`) and notes dashboard header (`NotesGrid.tsx`), ensuring consistent access to the self hub from main dashboard views. [[1]](diffhunk://#diff-c45e0e0f58b1afed914a31133a8ebad875d0ad0c82fe05ec260c05da0fcb0fcdR49-R61) [[2]](diffhunk://#diff-f006fcc49490b503fb942b2da5c214d19c779de2277bd51fd4eaef4da7964232R326-R345)

**Notes and projects filtering improvements:**

* Refactored the notes and projects filtering logic in `NotesGrid.tsx` to use memoized filters for search, type, and tags, and simplified the combination and display of notes/projects. This replaces the previous deduplication and sorting logic, resulting in more accurate and performant filtering. [[1]](diffhunk://#diff-f006fcc49490b503fb942b2da5c214d19c779de2277bd51fd4eaef4da7964232L213-R279) [[2]](diffhunk://#diff-f006fcc49490b503fb942b2da5c214d19c779de2277bd51fd4eaef4da7964232L314-L328) [[3]](diffhunk://#diff-f006fcc49490b503fb942b2da5c214d19c779de2277bd51fd4eaef4da7964232L466-R480) [[4]](diffhunk://#diff-f006fcc49490b503fb942b2da5c214d19c779de2277bd51fd4eaef4da7964232L491-R490)
* Improved empty state messaging in `NotesGrid.tsx` to provide clearer feedback based on filters and search criteria.

**Component improvements:**

* Updated `PersonaTab` to accept `isEditMode` and `onEditModeChange` props, allowing for more flexible persona editing state management and improved integration with parent components. [[1]](diffhunk://#diff-336e384cb2da1d76685ac157cc99a4782ea9776afbb82d3345465b1f39a2142cL89-R94) [[2]](diffhunk://#diff-336e384cb2da1d76685ac157cc99a4782ea9776afbb82d3345465b1f39a2142cR266-R267) [[3]](diffhunk://#diff-336e384cb2da1d76685ac157cc99a4782ea9776afbb82d3345465b1f39a2142cR295-R296)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added Self tab in Chat and Notes.
  - Introduced persona edit/save/cancel and delete with confirmation.
  - Enabled external control of persona edit mode.
  - Added Command/Ctrl+K shortcut and “+” button to open AI assistant.
  - Suggestion chips now insert text into input.
  - Header logo now links home.

- UI/UX
  - Redesigned persona view and edit form for clarity.
  - Simplified notes/projects filtering with improved empty states.
  - AI Actions palette shows non-interactive preview with status footer.
  - Improved input handling and layout consistency.

- Style
  - Minor spacing and layout adjustments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->