### PR TITLE
Remove user input hint from CommandPaletteHeader component

### DIFF
--- a/src/app/dashboard/notes/components/CommandPaletteHeader.tsx
+++ b/src/app/dashboard/notes/components/CommandPaletteHeader.tsx
@@ -106,11 +106,6 @@ export function CommandPaletteHeader({
                 className="w-full px-2 py-1 text-sm bg-transparent border-none focus:outline-none text-foreground placeholder:text-muted-foreground"
                 disabled={operationState.isOperationInProgress || refinementState.isProcessingRefinement}
               />
-              {userInput.trim() && (
-                <div className="mt-1 text-xs text-muted-foreground">
-                  Press <kbd className="px-1 py-0.5 text-xs font-semibold text-gray-800 bg-gray-100 border border-gray-200 rounded dark:bg-gray-700 dark:text-gray-100 dark:border-gray-600">Enter</kbd> to {refinementMode ? 'refine' : 'generate'} with: "{userInput}"
-                </div>
-              )}
             </div>
           ) : (
             <span className="text-sm text-muted-foreground flex items-center gap-2">


### PR DESCRIPTION
This pull request makes a small UI change in the `CommandPaletteHeader` component. The change removes the contextual hint that showed users which action would be performed when pressing Enter, streamlining the input experience.

* Removed the hint below the input field that displayed "Press Enter to generate/refine with: ..." based on the current mode and user input.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Cleaned up the command palette header by removing the inline hint beneath the input (“Press Enter to …”), reducing visual clutter.
* **Refactor**
  * Transitioned the command palette input to be externally controlled for more consistent behavior. No changes to how users interact: pressing Enter still runs the current input, and placeholders and mode display remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->