### PR TITLE
Fixes/crystals

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -45,6 +45,7 @@ import type * as intelligenceMutations from "../intelligenceMutations.js";
 import type * as intelligenceQueries from "../intelligenceQueries.js";
 import type * as intelligenceScheduled from "../intelligenceScheduled.js";
 import type * as internal_ from "../internal.js";
+import type * as migrations_migrateReservedShards from "../migrations/migrateReservedShards.js";
 import type * as migrations from "../migrations.js";
 import type * as noteMutations from "../noteMutations.js";
 import type * as noteQueries from "../noteQueries.js";
@@ -123,6 +124,7 @@ declare const fullApi: ApiFromModules<{
   intelligenceQueries: typeof intelligenceQueries;
   intelligenceScheduled: typeof intelligenceScheduled;
   internal: typeof internal_;
+  "migrations/migrateReservedShards": typeof migrations_migrateReservedShards;
   migrations: typeof migrations;
   noteMutations: typeof noteMutations;
   noteQueries: typeof noteQueries;

--- a/convex/http.ts
+++ b/convex/http.ts
@@ -1375,25 +1375,6 @@ app.delete("/api/project-widgets/delete", async (c) => {
   }
 });
 
-// Helper to transform reserved status in responses for backend compatibility
-// Recursively transforms 'reserved' to 'unprocessed' in any response structure
-const transformReservedStatus = (result: any): any => {
-  if (!result) return result;
-  
-  if (Array.isArray(result)) {
-    result.forEach((item: any) => {
-      if (item?.shard_status === 'reserved') item.shard_status = 'unprocessed';
-    });
-  } else if (typeof result === 'object') {
-    if (result.shard_status === 'reserved') result.shard_status = 'unprocessed';
-    if (result.shards && Array.isArray(result.shards)) {
-      result.shards.forEach((item: any) => {
-        if (item?.shard_status === 'reserved') item.shard_status = 'unprocessed';
-      });
-    }
-  }
-  return result;
-};
 
 // Single query endpoint that mirrors getCrystalData exactly
 app.post("/api/crystal/query", async (c) => {
@@ -1402,7 +1383,7 @@ app.post("/api/crystal/query", async (c) => {
   
   try {
     const result = await ctx.runQuery(api.crystalQueries.getCrystalData, requestBody);
-    return c.json({ success: true, data: transformReservedStatus(result) });
+    return c.json({ success: true, data: result });
   } catch (error: any) {
     return c.json({ success: false, error: error.message }, 500);
   }
@@ -1415,7 +1396,7 @@ app.post("/api/crystal/mutate", async (c) => {
   
   try {
     const result = await ctx.runMutation(api.crystalMutations.mutateCrystalData, requestBody);
-    return c.json({ success: true, data: transformReservedStatus(result) });
+    return c.json({ success: true, data: result });
   } catch (error: any) {
     return c.json({ success: false, error: error.message }, 500);
   }
@@ -1428,7 +1409,7 @@ app.post("/api/crystal/batch-mutate", async (c) => {
   
   try {
     const result = await ctx.runMutation(api.crystalMutations.batchMutateCrystalData, requestBody);
-    return c.json({ success: true, data: transformReservedStatus(result) });
+    return c.json({ success: true, data: result });
   } catch (error: any) {
     return c.json({ success: false, error: error.message }, 500);
   }
@@ -1840,7 +1821,8 @@ app.post("/api/shard-lifecycle/unprocessed", async (c) => {
   
   try {
     const result = await ctx.runQuery(api.shardLifecycleQueries.getUnprocessedShards, requestBody);
-    return c.json({ success: true, data: transformReservedStatus(result) });
+    // Return raw result - backend's call_convex_api will wrap it in { success, data }
+    return c.json(result);
   } catch (error: any) {
     return c.json({ success: false, error: error.message }, 500);
   }
@@ -1876,7 +1858,43 @@ app.post("/api/shard-lifecycle/initialize-legacy", async (c) => {
   
   try {
     const result = await ctx.runMutation(api.shardLifecycleMutations.initializeLegacyShardStatus, requestBody);
-    return c.json({ success: true, data: transformReservedStatus(result) });
+    return c.json({ success: true, data: result });
+  } catch (error: any) {
+    return c.json({ success: false, error: error.message }, 500);
+  }
+});
+
+app.post("/api/shard-lifecycle/release-stuck", async (c) => {
+  const ctx = c.env;
+  const requestBody = await c.req.json();
+  
+  try {
+    const result = await ctx.runMutation(api.shardLifecycleMutations.releaseStuckReservedShards, requestBody);
+    return c.json({ success: true, data: result });
+  } catch (error: any) {
+    return c.json({ success: false, error: error.message }, 500);
+  }
+});
+
+// === MIGRATIONS ===
+app.post("/api/migrations/reserved-shards", async (c) => {
+  const ctx = c.env;
+  const requestBody = await c.req.json();
+  
+  try {
+    const result = await ctx.runMutation(api.migrations.migrateReservedShards.migrateReservedShardsToUnprocessed, requestBody);
+    return c.json({ success: true, data: result });
+  } catch (error: any) {
+    return c.json({ success: false, error: error.message }, 500);
+  }
+});
+
+app.get("/api/migrations/shard-status-distribution", async (c) => {
+  const ctx = c.env;
+  
+  try {
+    const result = await ctx.runMutation(api.migrations.migrateReservedShards.getShardStatusDistribution, {});
+    return c.json({ success: true, data: result });
   } catch (error: any) {
     return c.json({ success: false, error: error.message }, 500);
   }
@@ -1891,7 +1909,7 @@ app.post("/api/shard-status/update", async (c) => {
   
   try {
     const result = await ctx.runMutation(api.shardStatusManager.updateShardStatus, requestBody);
-    return c.json({ success: true, data: transformReservedStatus(result) });
+    return c.json({ success: true, data: result });
   } catch (error: any) {
     return c.json({ success: false, error: error.message }, 500);
   }
@@ -1903,7 +1921,7 @@ app.post("/api/shard-status/release", async (c) => {
   
   try {
     const result = await ctx.runMutation(api.shardStatusManager.releaseReservedShards, requestBody);
-    return c.json({ success: true, data: transformReservedStatus(result) });
+    return c.json({ success: true, data: result });
   } catch (error: any) {
     return c.json({ success: false, error: error.message }, 500);
   }
@@ -1915,7 +1933,7 @@ app.post("/api/shard-status/reserve", async (c) => {
   
   try {
     const result = await ctx.runMutation(api.shardStatusManager.reserveShards, requestBody);
-    return c.json({ success: true, data: transformReservedStatus(result) });
+    return c.json({ success: true, data: result });
   } catch (error: any) {
     return c.json({ success: false, error: error.message }, 500);
   }
@@ -1927,7 +1945,7 @@ app.post("/api/shard-status/consume", async (c) => {
   
   try {
     const result = await ctx.runMutation(api.shardStatusManager.consumeShards, requestBody);
-    return c.json({ success: true, data: transformReservedStatus(result) });
+    return c.json({ success: true, data: result });
   } catch (error: any) {
     return c.json({ success: false, error: error.message }, 500);
   }
@@ -1939,7 +1957,7 @@ app.post("/api/shard-status/archive", async (c) => {
   
   try {
     const result = await ctx.runMutation(api.shardStatusManager.archiveShards, requestBody);
-    return c.json({ success: true, data: transformReservedStatus(result) });
+    return c.json({ success: true, data: result });
   } catch (error: any) {
     return c.json({ success: false, error: error.message }, 500);
   }

--- a/convex/http.ts
+++ b/convex/http.ts
@@ -1504,15 +1504,15 @@ const vectorSearchMutationSchema = z.object({
   maxConcurrent: z.number().int().positive().max(10).optional(),
 });
 
-// POST /api/vectorSearch/query - Optimized generic query endpoint
-app.post("/api/vectorSearch/query", async (c) => {
+// POST /api/vectorSearch/action - Optimized generic action endpoint (supports ctx.runAction)
+app.post("/api/vectorSearch/action", async (c) => {
   try {
     const requestBody = await c.req.json();
     const validation = vectorSearchQuerySchema.safeParse(requestBody);
     
     if (!validation.success) {
       return c.json({
-        error: "Invalid vector search query parameters",
+        error: "Invalid vector search action parameters",
         details: validation.error.flatten()
       }, 400);
     }
@@ -1523,17 +1523,18 @@ app.post("/api/vectorSearch/query", async (c) => {
       return c.json({ error: "userId and operation are required" }, 400);
     }
     
-    const result = await c.env.runQuery(api.vectorSearchQueries.getVectorSearchData, {
+    // Call as action instead of query to support ctx.runAction calls
+    const result = await c.env.runAction(api.vectorSearchQueries.getVectorSearchData, {
       userId,
       operation,
       ...rest
     });
     return c.json(result);
   } catch (error) {
-    console.error('Vector search query error:', error);
+    console.error('Vector search action error:', error);
     return c.json({ 
       success: false, 
-      error: 'Vector search query failed',
+      error: 'Vector search action failed',
       data: null 
     }, 500);
   }

--- a/convex/migrations/migrateReservedShards.ts
+++ b/convex/migrations/migrateReservedShards.ts
@@ -1,0 +1,165 @@
+import { mutation } from "../_generated/server";
+import { v } from "convex/values";
+
+/**
+ * ONE-TIME MIGRATION: Convert legacy 'reserved' shards to 'unprocessed'
+ * 
+ * Context: The 'reserved' status was used before distributed locking.
+ * Now that we have proper distributed locks, 'reserved' is obsolete and
+ * any shards stuck in that state are from failed formations.
+ * 
+ * This migration:
+ * 1. Finds all shards with status='reserved'
+ * 2. Converts them to 'unprocessed'
+ * 3. Clears reservation metadata (reserved_by_formation, reserved_at)
+ * 
+ * Safe to run multiple times - idempotent.
+ */
+export const migrateReservedShardsToUnprocessed = mutation({
+  args: {
+    dryRun: v.optional(v.boolean()),
+    batchSize: v.optional(v.number()),
+  },
+  handler: async (ctx, { dryRun = false, batchSize = 100 }) => {
+    const currentTime = Date.now();
+    
+    console.log(`[MIGRATION] Starting reserved shards migration (dryRun: ${dryRun})`);
+    
+    // Find all shards with reserved status
+    const allShards = await ctx.db
+      .query("crystal_shards")
+      .collect();
+    
+    const reservedShards = allShards.filter(shard => shard.shard_status === "reserved");
+    
+    console.log(`[MIGRATION] Found ${reservedShards.length} reserved shards out of ${allShards.length} total`);
+    
+    if (reservedShards.length === 0) {
+      return {
+        success: true,
+        message: "No reserved shards found - migration not needed",
+        migratedCount: 0,
+        totalShards: allShards.length,
+      };
+    }
+    
+    // Group by user for reporting
+    const byUser: Record<string, number> = {};
+    const migrationDetails: Array<{
+      shardId: string;
+      userId: string;
+      reservedBy?: string;
+      reservedAt?: number;
+      ageHours?: number;
+    }> = [];
+    
+    for (const shard of reservedShards) {
+      byUser[shard.userId] = (byUser[shard.userId] || 0) + 1;
+      
+      const ageHours = shard.reserved_at 
+        ? Math.floor((currentTime - shard.reserved_at) / (1000 * 60 * 60))
+        : undefined;
+      
+      migrationDetails.push({
+        shardId: shard._id,
+        userId: shard.userId,
+        reservedBy: shard.reserved_by_formation,
+        reservedAt: shard.reserved_at,
+        ageHours,
+      });
+    }
+    
+    console.log(`[MIGRATION] Reserved shards by user:`, byUser);
+    console.log(`[MIGRATION] Sample details:`, migrationDetails.slice(0, 5));
+    
+    if (dryRun) {
+      return {
+        success: true,
+        dryRun: true,
+        message: `DRY RUN: Would migrate ${reservedShards.length} reserved shards`,
+        affectedUsers: Object.keys(byUser).length,
+        byUser,
+        sampleDetails: migrationDetails.slice(0, 10),
+        totalReserved: reservedShards.length,
+      };
+    }
+    
+    // Perform migration in batches
+    let migratedCount = 0;
+    const batches = [];
+    
+    for (let i = 0; i < reservedShards.length; i += batchSize) {
+      const batch = reservedShards.slice(i, i + batchSize);
+      batches.push(batch);
+    }
+    
+    console.log(`[MIGRATION] Processing ${batches.length} batches of ${batchSize} shards each`);
+    
+    for (const batch of batches) {
+      for (const shard of batch) {
+        try {
+          await ctx.db.patch(shard._id, {
+            shard_status: "unprocessed",
+            reserved_by_formation: undefined,
+            reserved_at: undefined,
+            updatedAt: currentTime,
+          });
+          migratedCount++;
+        } catch (error) {
+          console.error(`[MIGRATION] Failed to migrate shard ${shard._id}:`, error);
+        }
+      }
+    }
+    
+    console.log(`[MIGRATION] Successfully migrated ${migratedCount} shards`);
+    
+    return {
+      success: true,
+      message: `Successfully migrated ${migratedCount} reserved shards to unprocessed`,
+      migratedCount,
+      totalReserved: reservedShards.length,
+      affectedUsers: Object.keys(byUser).length,
+      byUser,
+      sampleDetails: migrationDetails.slice(0, 10),
+    };
+  },
+});
+
+/**
+ * Check current shard status distribution
+ * Useful for verifying migration results
+ */
+export const getShardStatusDistribution = mutation({
+  args: {},
+  handler: async (ctx) => {
+    const allShards = await ctx.db.query("crystal_shards").collect();
+    
+    const distribution: Record<string, number> = {
+      unprocessed: 0,
+      reserved: 0,
+      used_for_crystal: 0,
+      archived: 0,
+      null: 0,
+    };
+    
+    const byUser: Record<string, Record<string, number>> = {};
+    
+    for (const shard of allShards) {
+      const status = shard.shard_status || "null";
+      distribution[status] = (distribution[status] || 0) + 1;
+      
+      if (!byUser[shard.userId]) {
+        byUser[shard.userId] = { unprocessed: 0, reserved: 0, used_for_crystal: 0, archived: 0, null: 0 };
+      }
+      byUser[shard.userId][status] = (byUser[shard.userId][status] || 0) + 1;
+    }
+    
+    return {
+      total: allShards.length,
+      distribution,
+      byUser,
+      timestamp: Date.now(),
+    };
+  },
+});
+

--- a/convex/shardLifecycleMutations.ts
+++ b/convex/shardLifecycleMutations.ts
@@ -77,6 +77,54 @@ export const initializeLegacyShardStatus = mutation({
 
 
 /**
+ * Release stuck reserved shards back to unprocessed
+ * 
+ * Fixes shards that are stuck in 'reserved' status from failed formations.
+ * Only releases shards that are reserved but not consumed.
+ */
+export const releaseStuckReservedShards = mutation({
+    args: {
+        userId: v.string(),
+    },
+    returns: v.object({
+        success: v.boolean(),
+        releasedCount: v.number(),
+        message: v.string(),
+    }),
+    handler: async (ctx, { userId }) => {
+        const currentTime = Date.now();
+        let releasedCount = 0;
+
+        // Get all reserved shards for user
+        const shards = await ctx.db
+            .query("crystal_shards")
+            .withIndex("by_user", (q) => q.eq("userId", userId))
+            .collect();
+
+        for (const shard of shards) {
+            // Only release shards that are:
+            // 1. In 'reserved' status
+            // 2. NOT consumed (no used_in_crystal_id)
+            if (shard.shard_status === "reserved" && !shard.used_in_crystal_id) {
+                await ctx.db.patch(shard._id, {
+                    shard_status: "unprocessed",
+                    reserved_by_formation: undefined,
+                    reserved_at: undefined,
+                    updatedAt: currentTime,
+                });
+                releasedCount++;
+            }
+        }
+
+        return {
+            success: true,
+            releasedCount,
+            message: `Released ${releasedCount} stuck reserved shards back to unprocessed`,
+        };
+    },
+});
+
+/**
  * Reset all shards for a user back to unprocessed status
  * DANGER: This is for debugging/recovery only
  */
@@ -113,6 +161,8 @@ export const resetUserShardStatus = mutation({
                 shard_status: "unprocessed",
                 used_in_crystal_id: undefined,
                 date_consumed: undefined,
+                reserved_by_formation: undefined,
+                reserved_at: undefined,
                 updatedAt: currentTime,
             });
             resetCount++;

--- a/convex/shardLifecycleQueries.ts
+++ b/convex/shardLifecycleQueries.ts
@@ -20,48 +20,99 @@ export const getUnprocessedShards = query({
     },
     returns: v.array(v.any()),
     handler: async (ctx, { userId, limit, minConfidence, dimensions }) => {
+        console.log(`[getUnprocessedShards] Starting query for user: ${userId}`);
+        console.log(`[getUnprocessedShards] Filters - limit: ${limit}, minConfidence: ${minConfidence}, dimensions: ${dimensions?.join(',') || 'none'}`);
+        
         // Get all shards for user and filter for unprocessed
         const allShards = await ctx.db
             .query("crystal_shards")
             .withIndex("by_user", (q) => q.eq("userId", userId))
             .collect();
 
+        console.log(`[getUnprocessedShards] Total shards found: ${allShards.length}`);
+        
+        // Count by status for debugging
+        const statusCounts: Record<string, number> = {};
+        let consumedCount = 0;
+        let recentReservedCount = 0;
+        let oldReservedCount = 0;
+        
         // Filter for TRULY unprocessed shards
+        // SOURCE OF TRUTH: used_in_crystal_id indicates actual consumption
         let results = allShards.filter(shard => {
-            // Explicitly exclude used, archived, or reserved shards
-            if (shard.shard_status === "used_for_crystal" || 
-                shard.shard_status === "archived" ||
-                shard.shard_status === "reserved") {
-                return false;
-            }
-            // CRITICAL: Exclude shards that are already consumed (have used_in_crystal_id)
+            const status = shard.shard_status || 'null';
+            statusCounts[status] = (statusCounts[status] || 0) + 1;
+            
+            // PRIMARY CHECK: Exclude shards that are actually consumed
             if (shard.used_in_crystal_id) {
+                consumedCount++;
+                console.log(`[getUnprocessedShards] Excluded - consumed: ${shard._id} (crystal: ${shard.used_in_crystal_id})`);
                 return false;
             }
-            // Only include shards that are explicitly unprocessed OR have no status (truly new)
-            return shard.shard_status === "unprocessed" || !shard.shard_status;
+            
+            // SECONDARY CHECK: Exclude archived shards
+            if (shard.shard_status === "archived") {
+                console.log(`[getUnprocessedShards] Excluded - archived: ${shard._id}`);
+                return false;
+            }
+            
+            // RESERVED SHARDS: Allow if older than 10 minutes (stuck/failed formation)
+            // This prevents permanent blocking while still protecting recent formations
+            if (shard.shard_status === "reserved") {
+                const tenMinutesAgo = Date.now() - (10 * 60 * 1000);
+                const reservedAge = shard.reserved_at ? Date.now() - shard.reserved_at : 'unknown';
+                const reservedAgeMinutes = typeof reservedAge === 'number' ? Math.floor(reservedAge / 60000) : 'unknown';
+                
+                // If reserved recently, exclude (active formation)
+                if (shard.reserved_at && shard.reserved_at > tenMinutesAgo) {
+                    recentReservedCount++;
+                    console.log(`[getUnprocessedShards] Excluded - recently reserved: ${shard._id} (age: ${reservedAgeMinutes}min, formation: ${shard.reserved_by_formation})`);
+                    return false;
+                }
+                // If reserved long ago, include (stuck/failed formation)
+                oldReservedCount++;
+                console.log(`[getUnprocessedShards] Included - old reserved: ${shard._id} (age: ${reservedAgeMinutes}min, formation: ${shard.reserved_by_formation})`);
+            }
+            
+            // Include all other shards (unprocessed, null status, or old reserved)
+            return true;
         });
+
+        console.log(`[getUnprocessedShards] Status breakdown:`, statusCounts);
+        console.log(`[getUnprocessedShards] Exclusion counts - consumed: ${consumedCount}, recent reserved: ${recentReservedCount}, old reserved (included): ${oldReservedCount}`);
+        console.log(`[getUnprocessedShards] After basic filtering: ${results.length} shards`);
 
         // Filter by confidence level if specified
         if (minConfidence) {
+            const beforeCount = results.length;
             const confidenceOrder = { "low": 1, "medium": 2, "high": 3 };
             const minLevel = confidenceOrder[minConfidence];
             results = results.filter(shard => {
                 const shardLevel = confidenceOrder[shard.confidence_level as keyof typeof confidenceOrder] || 1;
                 return shardLevel >= minLevel;
             });
+            console.log(`[getUnprocessedShards] Confidence filter (${minConfidence}): ${beforeCount} -> ${results.length} shards`);
         }
 
         // Filter by dimensions if specified
         if (dimensions && dimensions.length > 0) {
+            const beforeCount = results.length;
             results = results.filter(shard => 
                 shard.dimension && dimensions.includes(shard.dimension)
             );
+            console.log(`[getUnprocessedShards] Dimension filter (${dimensions.join(',')}): ${beforeCount} -> ${results.length} shards`);
         }
 
         // Apply limit
         if (limit) {
+            const beforeCount = results.length;
             results = results.slice(0, limit);
+            console.log(`[getUnprocessedShards] Limit applied (${limit}): ${beforeCount} -> ${results.length} shards`);
+        }
+
+        console.log(`[getUnprocessedShards] FINAL RESULT: Returning ${results.length} unprocessed shards`);
+        if (results.length > 0) {
+            console.log(`[getUnprocessedShards] Sample shard IDs:`, results.slice(0, 5).map(s => s._id));
         }
 
         return results;
@@ -78,6 +129,7 @@ export const getShardConsumptionStats = query({
     returns: v.object({
         totalShards: v.number(),
         unprocessed: v.number(),
+        reserved: v.number(),
         usedForCrystal: v.number(),
         archived: v.number(),
         unknownStatus: v.number(),
@@ -94,6 +146,7 @@ export const getShardConsumptionStats = query({
         const stats = {
             totalShards: allShards.length,
             unprocessed: 0,
+            reserved: 0,
             usedForCrystal: 0,
             archived: 0,
             unknownStatus: 0,
@@ -107,6 +160,9 @@ export const getShardConsumptionStats = query({
             switch (shard.shard_status) {
                 case "unprocessed":
                     stats.unprocessed++;
+                    break;
+                case "reserved":
+                    stats.reserved++;
                     break;
                 case "used_for_crystal":
                     stats.usedForCrystal++;
@@ -269,3 +325,4 @@ export const getCrystalToShardMapping = query({
         return mapping;
     },
 });
+

--- a/convex/shardStatusManager.ts
+++ b/convex/shardStatusManager.ts
@@ -254,7 +254,8 @@ export const releaseReservedShards = mutation({
  * Reserve shards for crystal formation
  * 
  * Atomically marks shards as reserved to prevent concurrent formation runs
- * from using the same shards. Only transitions shards from unprocessed state.
+ * from using the same shards. Accepts shards from unprocessed or already
+ * reserved states (to allow re-reserving stuck/old reservations).
  * 
  * @param shardIds - Array of shard IDs to reserve
  * @param formationRunId - Formation run ID claiming these shards
@@ -277,7 +278,7 @@ export const reserveShards = mutation({
       shardIds,
       "reserved",
       { formationRunId },
-      ["unprocessed"]
+      ["unprocessed", "reserved"]  // Allow re-reserving old reservations
     );
 
     return {

--- a/convex/vectorSearchQueries.ts
+++ b/convex/vectorSearchQueries.ts
@@ -1,5 +1,6 @@
-import { query } from "./_generated/server";
+import { query, action } from "./_generated/server";
 import { v } from "convex/values";
+import { api } from "./_generated/api";
 
 /**
  * Optimized Vector Search Queries
@@ -63,8 +64,8 @@ const queryVectorSearchWithOptions = async (
   return options.limit ? await orderedQuery.take(options.limit) : await orderedQuery.take(50);
 };
 
-// Single generic vector search query function
-export const getVectorSearchData = query({
+// Single generic vector search action function (changed from query to support ctx.runAction)
+export const getVectorSearchData = action({
   args: {
     userId: v.string(),
     operation: v.string(),

--- a/src/app/api/lab/message/route.ts
+++ b/src/app/api/lab/message/route.ts
@@ -81,14 +81,15 @@ export async function POST(request: Request) {
     }
 
     console.log(`[${requestId}] Forwarding to chat API:`, {
-      url: `${BACKEND_URL}/api/v1/chat`,
+      url: `${BACKEND_URL}/api/v1/chat/message`,
       user_id: authenticated_user_id,
       query_length: query.length,
+      has_notepad_context: !!chatRequestBody.notepad_context,
       has_content_context: !!chatRequestBody.content_context
     });
 
-    // Forward to existing chat API
-    const response = await fetch(`${BACKEND_URL}/api/v1/chat`, {
+    // Forward to chat message endpoint
+    const response = await fetch(`${BACKEND_URL}/api/v1/chat/message`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -110,14 +111,17 @@ export async function POST(request: Request) {
 
     const data = await response.json();
     
+    // Backend wraps response in { success: true, data: {...} }
+    const backendData = data.success ? data.data : data;
+    
     // Transform chat API response to thinking lab format
     const labResponse = {
-      response_content: data.response || data.chat_response,
-      session_identifier: data.session_id,
-      user_input: data.user_message || query,
-      suggestions: data.suggestions || [],
+      response_content: backendData.response || backendData.chat_response || 'No response received',
+      session_identifier: backendData.session_id || session_identifier,
+      user_input: backendData.user_message || query,
+      suggestions: backendData.suggestions || [],
       metadata: {
-        ...data.metadata,
+        ...backendData.metadata,
         request_id: requestId,
         processing_time_ms: Date.now() - startTime
       }
@@ -126,7 +130,8 @@ export async function POST(request: Request) {
     console.log(`[${requestId}] Lab message request completed`, {
       duration_ms: Date.now() - startTime,
       response_length: labResponse.response_content?.length || 0,
-      suggestions_count: labResponse.suggestions?.length || 0
+      suggestions_count: labResponse.suggestions?.length || 0,
+      has_notepad_context: !!chatRequestBody.notepad_context
     });
 
     return NextResponse.json(labResponse);

--- a/src/app/dashboard/thinking_lab/components/notepad/hooks/useNotepadHandlers.ts
+++ b/src/app/dashboard/thinking_lab/components/notepad/hooks/useNotepadHandlers.ts
@@ -1,6 +1,7 @@
 'use client'
 
 import { useCallback, useEffect, useRef } from 'react'
+import { useNotepadStore } from '../../../stores/notepadStore'
 import type { Note, NoteUpdate } from '../../../../notes/types'
 import type { Id } from "@/convex/_generated/dataModel"
 import type { NoteHandlers, NotepadState, NotepadRefs } from '../types'
@@ -316,6 +317,9 @@ export function useNotepadHandlers({
     }
     
     setContent(newContent)
+    
+    // Sync with notepad store for cross-component access (e.g., chat can include notepad context)
+    useNotepadStore.getState().updateContent(newContent)
     
     // Clear existing auto-save timeout
     if (autoSaveTimeoutRef.current) {

--- a/src/app/dashboard/thinking_lab/components/notepad/hooks/useNotepadState.ts
+++ b/src/app/dashboard/thinking_lab/components/notepad/hooks/useNotepadState.ts
@@ -6,6 +6,7 @@ import { useNotes } from '@/app/context/notes-context'
 import { useCreateNote } from '@/app/dashboard/notes/hooks/useCreateNote'
 import { useQuery } from 'convex/react'
 import { api } from '@/convex/_generated/api'
+import { useNotepadStore } from '../../../stores/notepadStore'
 import type { Note, NoteUpdate } from '../../../../notes/types'
 import type { Id } from "@/convex/_generated/dataModel"
 import type { LexicalNotepadEditorRef } from '@/components/ui/lexical-editor/LexicalNotepadEditor'
@@ -109,6 +110,13 @@ export function useNotepadState({
     // REMOVED: Premature content clearing that caused erratic behavior
     // Only set content when we actually have note data, never clear preemptively
   }, [existingNote?._id]) // Simplified dependencies - only re-run when note ID changes
+
+  // Sync note title to notepad store for cross-component access
+  useEffect(() => {
+    const title = note.title || 'Untitled Note'
+    useNotepadStore.getState().updateTitle(title)
+    useNotepadStore.getState().setCurrentNoteId(currentNoteId as string)
+  }, [note.title, currentNoteId])
 
   // Handle quoted content insertion
   useEffect(() => {

--- a/src/app/dashboard/thinking_lab/compositions/LabCompositions.tsx
+++ b/src/app/dashboard/thinking_lab/compositions/LabCompositions.tsx
@@ -10,6 +10,7 @@
 import React from 'react'
 import { Columns2 } from 'lucide-react'
 import { useDialogueStore } from '../stores/dialogueStore'
+import { useNotepadStore } from '../stores/notepadStore'
 import { MarkdownNotepad } from '../components/notepad/MarkdownNotepad'
 import ChatInputArea from '../components/dialogue/input/ChatInputArea'
 import { BottomBarActions } from '../components/dialogue/components/BottomBarActions'
@@ -145,10 +146,10 @@ NotepadPanel.displayName = 'NotepadPanel'
 
 function useInputSection(clearQuotedContent: () => void) {
   const { isLoading, sendMessage } = useDialogueStore()
+  const { includeInMessages, setIncludeInMessages } = useNotepadStore()
   const inputRef = React.useRef<HTMLTextAreaElement>(null)
   const [inputValue, setInputValue] = React.useState("")
   const [useContextSearch, setUseContextSearch] = React.useState(true)
-  const [includeNotepadInMessages, setIncludeNotepadInMessages] = React.useState(false)
 
   const handleInputPopulate = React.useCallback((text: string) => {
     const cleanText = text
@@ -183,8 +184,8 @@ function useInputSection(clearQuotedContent: () => void) {
       embeddingInfo={{ hasEmbeddings: false, count: 0 }}
       useContextSearch={useContextSearch}
       onToggleContextSearch={setUseContextSearch}
-      includeNotepadInMessages={includeNotepadInMessages}
-      onToggleNotepadInMessages={setIncludeNotepadInMessages}
+      includeNotepadInMessages={includeInMessages}
+      onToggleNotepadInMessages={setIncludeInMessages}
     />
   ), [
     sendMessage,
@@ -194,8 +195,8 @@ function useInputSection(clearQuotedContent: () => void) {
     handleInputPopulate,
     useContextSearch,
     setUseContextSearch,
-    includeNotepadInMessages,
-    setIncludeNotepadInMessages,
+    includeInMessages,
+    setIncludeInMessages,
     clearQuotedContent
   ])
 

--- a/src/app/dashboard/thinking_lab/modules/api/messageService.ts
+++ b/src/app/dashboard/thinking_lab/modules/api/messageService.ts
@@ -26,7 +26,16 @@ import type {
  * This calls /api/chat/message which forwards to the backend.
  */
 export async function transmitMessageWithContext(params: MessageTransmissionRequest): Promise<LabResponseData> {
-  const { content, useContextSearch = true, fileAttachments, onStatusUpdate } = params;
+  const { 
+    content, 
+    useContextSearch = true, 
+    fileAttachments,
+    notepadContext,
+    workspaceContext,
+    isFirstMessage,
+    sessionIdentifier,
+    onStatusUpdate 
+  } = params;
   
   // Auth readiness and userId resolution with retry
   onStatusUpdate?.('Preparing secure session...');
@@ -54,16 +63,15 @@ export async function transmitMessageWithContext(params: MessageTransmissionRequ
     onStatusUpdate?.('Processing your request...');
     onStatusUpdate?.('Searching for relevant context...');
 
-    // Prepare request body with file attachments
+    // Prepare request body for thinking lab endpoint
     const requestBody: any = {
       user_id: userId,
       query: content,
-      content_types: ["note", "crystal", "conversation"],
-      include_context: useContextSearch,
-      max_results: 10,
-      similarity_threshold: 0.7,
-      generate_embeddings: false,
-      store_conversation: true
+      is_first_message: isFirstMessage,
+      session_identifier: sessionIdentifier,
+      notepad_context: notepadContext,
+      workspace_context: workspaceContext,
+      use_vector_search: useContextSearch
     };
 
     // Add file attachments if present
@@ -71,38 +79,54 @@ export async function transmitMessageWithContext(params: MessageTransmissionRequ
       requestBody.file_attachments = fileAttachments;
     }
 
-    // Call the Next.js API route
-    const response = await fetchWithApiKey('/api/chat/message', {
+    console.log('[MessageService] Sending to lab endpoint:', {
+      url: '/api/lab/message',
+      hasNotepadContext: !!notepadContext,
+      notepadContentLength: notepadContext?.content?.length || 0,
+      hasWorkspaceContext: !!workspaceContext,
+      isFirstMessage,
+      sessionIdentifier
+    });
+
+    // Call the thinking lab API endpoint (not the generic chat endpoint)
+    const response = await fetchWithApiKey('/api/lab/message', {
       method: 'POST',
       body: JSON.stringify(requestBody)
     });
 
     if (!response.ok) {
+      console.error('[MessageService] Response not OK:', response.status, response.statusText);
       throw new Error(`HTTP ${response.status}: ${response.statusText}`);
     }
 
     const data = await response.json();
+    console.log('[MessageService] Received response from API:', {
+      hasData: !!data,
+      dataKeys: Object.keys(data),
+      hasResponseContent: !!data.response_content,
+      responseContentLength: data.response_content?.length,
+      hasSessionId: !!data.session_identifier,
+      data: data
+    });
+    
     onStatusUpdate?.('Generating response...');
     
-    // Transform backend response to expected format
-    if (data.success && data.data) {
-      return {
-        response_content: data.data.response || generateResponseFromContext(data.data),
-        session_identifier: data.data.session_id || `session-${Date.now()}`,
-        user_input: content, // Use the original user input
-        suggestions: data.data.suggestions || [],
-        metadata: data.data.metadata || {}
-      };
-    }
-    
-    // Handle error case
-    return {
-      response_content: data.error || 'No response received',
-      session_identifier: `session-${Date.now()}`,
-      user_input: content,
-      suggestions: [],
-      metadata: { error: data.error }
+    // Lab endpoint returns the response directly (not wrapped in success/data)
+    const result = {
+      response_content: data.response_content || 'No response received',
+      session_identifier: data.session_identifier || `session-${Date.now()}`,
+      user_input: data.user_input || content,
+      suggestions: data.suggestions || [],
+      metadata: data.metadata || {}
     };
+    
+    console.log('[MessageService] Returning result:', {
+      response_content_length: result.response_content.length,
+      session_identifier: result.session_identifier,
+      has_suggestions: result.suggestions.length > 0
+    });
+    
+    return result;
 
   } catch (error) {
     if (error instanceof AuthenticationError) {

--- a/src/app/dashboard/thinking_lab/stores/dialogueStore.ts
+++ b/src/app/dashboard/thinking_lab/stores/dialogueStore.ts
@@ -11,6 +11,7 @@ import { subscribeWithSelector } from 'zustand/middleware'
 // Import API services
 import { transmitMessageWithContext } from '../modules/api/messageService'
 import { useLayoutStore } from './layoutStore' // For getting context preferences
+import { useNotepadStore } from './notepadStore' // For getting notepad context
 
 // Import proper chat types for compatibility
 import type { Message } from '@/app/types/chat'
@@ -65,12 +66,29 @@ export const useDialogueStore = create<DialogueStore>()(
             })
 
             try {
+                // Get notepad context if enabled
+                const notepadState = useNotepadStore.getState()
+                const notepadContext = notepadState.includeInMessages && notepadState.currentContent
+                    ? {
+                        content: notepadState.currentContent,
+                        title: notepadState.currentTitle || 'Untitled'
+                      }
+                    : null
+                
+                console.log('[DialogueStore] Sending message with notepad context:', {
+                    hasNotepadContext: !!notepadContext,
+                    includeInMessages: notepadState.includeInMessages,
+                    contentLength: notepadState.currentContent.length,
+                    title: notepadState.currentTitle
+                })
+
                 // Prepare request parameters
                 const requestParams: MessageTransmissionRequest = {
                     content,
                     isFirstMessage: messages.length === 0,
                     sessionIdentifier: sessionId,
                     workspaceContext: conversationId ? { contentId: conversationId } : null,
+                    notepadContext, // Include notepad context
                     useContextSearch,
                     fileAttachments,
                     onStatusUpdate: (status: string) => {
@@ -92,6 +110,14 @@ export const useDialogueStore = create<DialogueStore>()(
 
                 // Call the enhanced message service
                 const response = await transmitMessageWithContext(requestParams)
+                
+                console.log('[DialogueStore] Received response from messageService:', {
+                    hasResponse: !!response,
+                    responseKeys: response ? Object.keys(response) : [],
+                    response_content: response?.response_content,
+                    response_content_length: response?.response_content?.length,
+                    session_identifier: response?.session_identifier
+                })
 
                 // Create assistant message from response
                 const assistantMessage: Message = {

--- a/src/app/dashboard/thinking_lab/stores/notepadStore.ts
+++ b/src/app/dashboard/thinking_lab/stores/notepadStore.ts
@@ -1,0 +1,64 @@
+/**
+ * Notepad Store
+ *
+ * Zustand store for managing notepad state that can be accessed by other stores.
+ * This allows the dialogue store to include notepad content in chat messages.
+ */
+
+import { create } from 'zustand'
+
+interface NotepadState {
+  // Current notepad content
+  currentContent: string
+  currentTitle: string
+  currentNoteId: string | null
+  
+  // Toggle for including notepad in messages
+  includeInMessages: boolean
+  
+  // Actions
+  updateContent: (content: string) => void
+  updateTitle: (title: string) => void
+  setCurrentNoteId: (noteId: string | null) => void
+  setIncludeInMessages: (include: boolean) => void
+  clearNotepad: () => void
+}
+
+export const useNotepadStore = create<NotepadState>()((set) => ({
+  // Initial state
+  currentContent: '',
+  currentTitle: 'Untitled',
+  currentNoteId: null,
+  includeInMessages: false,
+  
+  // Actions
+  updateContent: (content: string) => {
+    set({ currentContent: content })
+  },
+  
+  updateTitle: (title: string) => {
+    set({ currentTitle: title })
+  },
+  
+  setCurrentNoteId: (noteId: string | null) => {
+    set({ currentNoteId: noteId })
+  },
+  
+  setIncludeInMessages: (include: boolean) => {
+    set({ includeInMessages: include })
+  },
+  
+  clearNotepad: () => {
+    set({
+      currentContent: '',
+      currentTitle: 'Untitled',
+      currentNoteId: null
+    })
+  }
+}))
+
+// Selectors for convenience
+export const useNotepadContent = () => useNotepadStore(state => state.currentContent)
+export const useNotepadTitle = () => useNotepadStore(state => state.currentTitle)
+export const useIncludeNotepadInMessages = () => useNotepadStore(state => state.includeInMessages)
+


### PR DESCRIPTION
This pull request introduces significant improvements to how shard statuses are managed and migrated in the backend, focusing on eliminating legacy "reserved" states and increasing transparency for debugging and recovery. The main changes include removing the automatic transformation of "reserved" to "unprocessed" in API responses, adding explicit migration and recovery endpoints, and improving the logic for identifying truly unprocessed shards. Additionally, new migration scripts and queries have been added to facilitate the transition and monitoring of shard statuses.

**Shard Status Migration and Recovery**

* Added new mutations in `convex/migrations/migrateReservedShards.ts` to migrate all shards with status "reserved" to "unprocessed" and to report current shard status distribution for monitoring and verification. These migrations are idempotent and provide detailed reporting by user and status.
* Introduced the `releaseStuckReservedShards` mutation in `convex/shardLifecycleMutations.ts` to allow explicit release of shards stuck in "reserved" status for a given user, returning them to "unprocessed" if they have not been consumed.
* Enhanced the `resetUserShardStatus` mutation to also clear reservation metadata (`reserved_by_formation`, `reserved_at`) when resetting shards, ensuring a clean state.

**API Endpoint Updates**

* Removed the `transformReservedStatus` helper and stopped transforming "reserved" to "unprocessed" in API responses, so clients now receive the raw shard status as stored in the database. This affects multiple endpoints in `convex/http.ts`, including crystal, shard lifecycle, and shard status APIs. [[1]](diffhunk://#diff-22ae6ac3563719a97f99af3980d10844cb0544e14f25f6c2ca41155c4c86eea5L1378-L1396) [[2]](diffhunk://#diff-22ae6ac3563719a97f99af3980d10844cb0544e14f25f6c2ca41155c4c86eea5L1405-R1386) [[3]](diffhunk://#diff-22ae6ac3563719a97f99af3980d10844cb0544e14f25f6c2ca41155c4c86eea5L1418-R1399) [[4]](diffhunk://#diff-22ae6ac3563719a97f99af3980d10844cb0544e14f25f6c2ca41155c4c86eea5L1431-R1412) [[5]](diffhunk://#diff-22ae6ac3563719a97f99af3980d10844cb0544e14f25f6c2ca41155c4c86eea5L1843-R1826) [[6]](diffhunk://#diff-22ae6ac3563719a97f99af3980d10844cb0544e14f25f6c2ca41155c4c86eea5L1894-R1913) [[7]](diffhunk://#diff-22ae6ac3563719a97f99af3980d10844cb0544e14f25f6c2ca41155c4c86eea5L1906-R1925) [[8]](diffhunk://#diff-22ae6ac3563719a97f99af3980d10844cb0544e14f25f6c2ca41155c4c86eea5L1918-R1937) [[9]](diffhunk://#diff-22ae6ac3563719a97f99af3980d10844cb0544e14f25f6c2ca41155c4c86eea5L1930-R1949) [[10]](diffhunk://#diff-22ae6ac3563719a97f99af3980d10844cb0544e14f25f6c2ca41155c4c86eea5L1942-R1961)
* Added new endpoints for migration and stuck shard release, including `/api/migrations/reserved-shards`, `/api/migrations/shard-status-distribution`, and `/api/shard-lifecycle/release-stuck`, providing admin tools for maintenance and monitoring.

**Unprocessed Shard Detection Improvements**

* Refined the logic in `getUnprocessedShards` (in `convex/shardLifecycleQueries.ts`) to more accurately identify truly unprocessed shards by:
  - Excluding shards that have been consumed (`used_in_crystal_id`) or are archived.
  - Allowing "reserved" shards to be considered unprocessed only if they have been reserved for more than 10 minutes (i.e., failed or stuck formations).
  - Adding extensive logging for debugging, including status breakdowns and exclusion reasons.

**Vector Search Endpoint Refactor**

* Changed the vector search endpoint from `/api/vectorSearch/query` to `/api/vectorSearch/action` and refactored its implementation to use `ctx.runAction` instead of `ctx.runQuery`, improving compatibility and error reporting. [[1]](diffhunk://#diff-22ae6ac3563719a97f99af3980d10844cb0544e14f25f6c2ca41155c4c86eea5L1526-R1515) [[2]](diffhunk://#diff-22ae6ac3563719a97f99af3980d10844cb0544e14f25f6c2ca41155c4c86eea5L1545-R1537)

These changes collectively improve the reliability, maintainability, and transparency of shard status management, making it easier to recover from legacy issues and monitor the health of the system.