### PR TITLE
feat: Auto-display widget opening messages as chat bubbles in thinkin…

### DIFF
--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -753,6 +753,7 @@ export default defineSchema({
       text: v.string(),
       priority: v.number(),
     })),
+    openingMessage: v.optional(v.string()),  // AI's first conversational message to start the dialogue
     
     // Metadata
     createdAt: v.number(),

--- a/convex/widgetOutputsMutations.ts
+++ b/convex/widgetOutputsMutations.ts
@@ -21,6 +21,7 @@ const operationSchema = v.object({
       text: v.string(),
       priority: v.number(),
     }))),
+    openingMessage: v.optional(v.string()),  // AI's first conversational message
   })),
   id: v.optional(v.id("widget_outputs")),
   outputId: v.optional(v.string()), // For delete by outputId
@@ -73,6 +74,7 @@ export const batchMutateWidgetOutputs = mutation({
               userId: op.data.userId,
               noteId: op.data.noteId!,
               prompts: op.data.prompts || [],
+              openingMessage: op.data.openingMessage,
               createdAt: Date.now(),
             });
             break;

--- a/src/app/dashboard/living-projects/[projectId]/widgets/[widgetId]/types.ts
+++ b/src/app/dashboard/living-projects/[projectId]/widgets/[widgetId]/types.ts
@@ -16,6 +16,7 @@ export interface WidgetOutput {
     text: string
     priority: number
   }>
+  openingMessage?: string  // AI's first conversational message to start the dialogue
   createdAt: number
 }
 

--- a/src/app/dashboard/thinking_lab/components/WidgetPrompts.tsx
+++ b/src/app/dashboard/thinking_lab/components/WidgetPrompts.tsx
@@ -110,6 +110,12 @@ export const WidgetPrompts: React.FC<WidgetPromptsProps> = ({
     );
   }
 
+  // If there's an opening message, don't render anything
+  // The opening message will be shown as a chat bubble with suggestion chips
+  if (parsedOutput?.openingMessage) {
+    return null;
+  }
+
   return (
     <PromptsContainer>
       <div className="space-y-4 py-4">

--- a/src/app/dashboard/thinking_lab/compositions/LabCompositions.tsx
+++ b/src/app/dashboard/thinking_lab/compositions/LabCompositions.tsx
@@ -9,6 +9,8 @@
 
 import React from 'react'
 import { Columns2 } from 'lucide-react'
+import { useQuery } from 'convex/react'
+import { api } from '@/convex/_generated/api'
 import { useDialogueStore } from '../stores/dialogueStore'
 import { useNotepadStore } from '../stores/notepadStore'
 import { MarkdownNotepad } from '../components/notepad/MarkdownNotepad'
@@ -242,20 +244,69 @@ export function FullThinkingLab({
   projectId,
   widgetId
 }: LabCompositionProps) {
-  const { quotedContent, setQuotedContent, clearQuotedContent, resetForWidget } = useDialogueStore()
+  const { quotedContent, setQuotedContent, clearQuotedContent, resetForWidget, messages, addMessage } = useDialogueStore()
   const { inputComponent, handleInputPopulate } = useInputSection(clearQuotedContent)
   const resizable = useResizablePanes(0.5)
+  const [userId, setUserId] = React.useState<string | null>(null)
+  const [openingMessageSent, setOpeningMessageSent] = React.useState(false)
 
-  // Note: Context initialization is handled by page.tsx from URL params
-  // This component only needs to reset dialogue state when widget changes
+  // Get user ID
+  React.useEffect(() => {
+    const getUserId = async () => {
+      try {
+        const { getCurrentUserId } = await import('@/app/lib/api-helpers')
+        const id = await getCurrentUserId()
+        setUserId(id)
+      } catch (error) {
+        console.error('[FullThinkingLab] Failed to get user ID:', error)
+      }
+    }
+    getUserId()
+  }, [])
 
-  // Reset dialogue store when widget output ID changes
+  // Fetch widget output data to get opening message
+  const widgetOutputData = useQuery(
+    api.widgetOutputsQueries.getWidgetOutputData,
+    widgetOutputId && userId ? {
+      userId,
+      filters: { outputId: widgetOutputId },
+      limit: 1
+    } : 'skip'
+  )
+
+  // Reset dialogue store and opening message flag when widget changes
   React.useEffect(() => {
     if (widgetOutputId) {
       console.log('[FullThinkingLab] New widgetOutputId detected, resetting dialogue store:', widgetOutputId)
       resetForWidget()
+      setOpeningMessageSent(false)
     }
   }, [widgetOutputId, resetForWidget])
+
+  // Auto-send opening message when widget output loads
+  React.useEffect(() => {
+    if (!widgetOutputId || !widgetOutputData || openingMessageSent) return
+
+    const output = Array.isArray(widgetOutputData) ? widgetOutputData[0] : widgetOutputData
+    
+    if (output?.openingMessage && messages.length === 0) {
+      console.log('[FullThinkingLab] Auto-sending opening message from widget output')
+      
+      const aiMessage = {
+        id: `msg-${Date.now()}`,
+        content: output.openingMessage,
+        role: 'assistant' as const,
+        timestamp: Date.now().toString(),
+        chat_response: output.openingMessage,
+        status: 'delivered' as const,
+        suggestions: output.prompts?.map((p: any) => p.text) || [],
+        metadata: {}
+      }
+      
+      addMessage(aiMessage)
+      setOpeningMessageSent(true)
+    }
+  }, [widgetOutputId, widgetOutputData, openingMessageSent, messages.length, addMessage])
 
   // Auto-snap to full screen when dragged close to edges
   React.useEffect(() => {

--- a/src/lib/services/widgetService.ts
+++ b/src/lib/services/widgetService.ts
@@ -27,6 +27,7 @@ export interface WidgetRunResponse {
     text: string;
     priority: number;
   }>;
+  opening_message?: string;  // AI's first conversational message to start the dialogue
   user_id: string;
 }
 


### PR DESCRIPTION
…g lab

- Add openingMessage field to widget output schema and TypeScript types
- Implement auto-fetch and display of opening messages when lab opens with widget context
- Opening messages render as assistant chat bubbles with prompts as suggestion chips
- Hide WidgetPrompts conversation starter cards when opening message exists
- Opening messages are added to dialogue store on component mount for seamless UX
- Matches production behavior: AI greets user first, then shows clickable prompt suggestions