### PR TITLE
Add optional fields for user Stripe data update

### DIFF
--- a/convex/userMutations.ts
+++ b/convex/userMutations.ts
@@ -209,6 +209,9 @@ export const updateUserStripeData = mutation({
     updates: v.object({
       stripeCustomerId: v.optional(v.string()),
       stripeSubscriptionId: v.optional(v.string()),
+      email: v.optional(v.string()),
+      name: v.optional(v.string()),
+      default_payment_method: v.optional(v.string()),
       // Add more Stripe/user fields here as needed
     })
   },


### PR DESCRIPTION
- Enhanced the `updateUserStripeData` mutation to include optional fields for `email`, `name`, and `default_payment_method`, allowing for more comprehensive updates to user Stripe information.
- This change aims to improve the flexibility and usability of the mutation, accommodating additional user data as needed.