### PR TITLE
Add updateConversationMetadata mutation and corresponding API endpoin…

### DIFF
--- a/convex/chatMutations.ts
+++ b/convex/chatMutations.ts
@@ -624,6 +624,48 @@ handler: async (ctx, args) => {
 },
 });
 
+export const updateConversationMetadata = mutation({
+  args: {
+    userId: v.string(),
+    conversationId: v.id("conversations"),
+    metadata: v.any()
+  },
+  handler: async (ctx, args) => {
+    const doc = await ctx.db.get(args.conversationId);
+    if (!doc) {
+      throw new Error("Conversation not found");
+    }
+
+    // Type check to ensure it's a conversation document
+    if (!('userId' in doc)) {
+      throw new Error("Invalid document type - not a conversation");
+    }
+
+    const conversation = doc as any;
+
+    // Verify ownership
+    if (conversation.userId !== args.userId) {
+      throw new Error("Access denied: You don't have permission to update this conversation");
+    }
+
+    // Patch conversation with metadata fields (only update provided fields)
+    const updateData: any = {
+      updatedAt: Date.now()
+    };
+    
+    // Only update fields that are provided in metadata
+    if (args.metadata.awaitingInitialContext !== undefined) {
+      updateData.awaitingInitialContext = args.metadata.awaitingInitialContext;
+    }
+    
+    // Add other metadata fields here as needed
+    
+    await ctx.db.patch(args.conversationId, updateData);
+    
+    return true;
+  }
+});
+
 export const updateConversationTitle = mutation({
   args: {
     userId: v.string(),

--- a/convex/http.ts
+++ b/convex/http.ts
@@ -261,6 +261,23 @@ app.post("/api/users/:id/update_conversation_title", async (c) => {
   return c.json(result);
 });
 
+// Update conversation metadata (e.g., awaitingInitialContext)
+app.post("/api/chat/conversation/updateMetadata", async (c) => {
+  const ctx = c.env;
+  const { userId, conversationId, metadata } = await c.req.json();
+  
+  try {
+    const result = await ctx.runMutation(api.chatMutations.updateConversationMetadata, {
+      userId,
+      conversationId,
+      metadata
+    });
+    return c.json({ success: true, data: result });
+  } catch (error: any) {
+    return c.json({ success: false, error: error.message }, 500);
+  }
+});
+
 // Update conversation suggestions (async generation)
 app.post("/api/chat/updateSuggestions", async (c) => {
   const ctx = c.env;

--- a/convex/types/conversation.ts
+++ b/convex/types/conversation.ts
@@ -63,6 +63,9 @@ export const conversationSchemaFields = {
   // 🔄 MIGRATION TRACKING: Temporary fields for migration
   migrated: v.optional(v.boolean()),  // Track migration status
   migrationVerified: v.optional(v.boolean()),  // Verify data integrity
+  
+  // Early message context gate - pause orchestrator until user responds
+  awaitingInitialContext: v.optional(v.boolean()),
 };
 
 export const conversationValidator = v.object(conversationSchemaFields);


### PR DESCRIPTION
…t for updating conversation metadata

- Introduced a new mutation, `updateConversationMetadata`, to allow users to update metadata fields of a conversation, including ownership verification and access control.
- Added an API endpoint to handle requests for updating conversation metadata, improving the flexibility of conversation management.
- Updated the conversation schema to include an optional `awaitingInitialContext` field, enhancing the metadata structure for conversations.

These changes aim to enhance conversation management capabilities and improve user experience in handling conversation metadata.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to update conversation metadata, enabling modifications to conversation information with proper access controls.
  * Introduced a context requirement mechanism that can pause conversations until initial context is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->