### PR TITLE
Enhance artifact queries and introduce version selection hook

### DIFF
--- a/convex/artifactQueries.ts
+++ b/convex/artifactQueries.ts
@@ -8,6 +8,7 @@
 import { v } from "convex/values";
 import { query } from "./_generated/server";
 import { api } from "./_generated/api";
+import { Id } from "./_generated/dataModel";
 
 /**
  * Get artifacts for a project
@@ -20,6 +21,34 @@ export const getProjectArtifacts = query({
   },
   handler: async (ctx, args) => {
     // ✅ FIX BLOCKER 3: Check project permission (owner or collaborator)
+    // First check if project exists and user owns it (fast path)
+    const project = await ctx.db.get(args.projectId);
+    if (!project) {
+      throw new Error("Project not found");
+    }
+    
+    // Fast path: User owns the project
+    if (project.userId === args.userId) {
+      return await ctx.db
+        .query("artifacts")
+        .withIndex("by_project", (q) => q.eq("projectId", args.projectId))
+        .order("desc")
+        .collect();
+    }
+    
+    // Check if user is a collaborator
+    const isCollaborator = project.collaborators?.some(
+      c => c.userId === args.userId
+    );
+    if (isCollaborator) {
+      return await ctx.db
+        .query("artifacts")
+        .withIndex("by_project", (q) => q.eq("projectId", args.projectId))
+        .order("desc")
+        .collect();
+    }
+    
+    // Fallback: Check shared access via permission helper
     const permission = await ctx.runQuery(api.contentAccessHelpers.getUserContentPermission, {
       userId: args.userId,
       contentType: "project",
@@ -173,7 +202,8 @@ export const queryArtifacts = query({
         : filters.widgetId;
       
       // ✅ FIX BLOCKER 3: Check widget/project permission
-      const widget = await ctx.db.get(widgetId);
+      // Cast widgetId to Id<"widgets"> to properly narrow the return type
+      const widget = await ctx.db.get(widgetId as Id<"widgets">);
       if (!widget) {
         throw new Error("Widget not found");
       }

--- a/src/components/artifacts/SchemaDrivenArtifactRenderer.tsx
+++ b/src/components/artifacts/SchemaDrivenArtifactRenderer.tsx
@@ -10,7 +10,7 @@
 
 'use client'
 
-import React, { useState, useEffect } from 'react'
+import React from 'react'
 import { Artifact, ArtifactRendererProps } from '@/types/artifacts'
 import { TableLayoutRenderer } from './layouts/renderers/TableLayoutRenderer'
 import { CardsLayoutRenderer } from './layouts/renderers/CardsLayoutRenderer'
@@ -25,6 +25,7 @@ import { Badge } from '@/components/ui/badge'
 import { useQuery } from 'convex/react'
 import { api } from '@/convex/_generated/api'
 import { Id } from '@/convex/_generated/dataModel'
+import { useArtifactVersionSelection } from '@/hooks/useArtifactVersionSelection'
 
 /**
  * Unsupported layout fallback
@@ -69,21 +70,15 @@ export function SchemaDrivenArtifactRenderer({
   editButton
 }: ArtifactRendererProps) {
   // CRITICAL: All hooks must be called before any early returns
-  // Version state management - must be at top level
+  // Version selection via URL state (source of truth)
   const artifactId = artifact ? ((artifact as any)._id || (artifact as any).id) : null;
   const currentArtifactVersion = artifact?.metadata?.version || 1;
-  const [selectedVersion, setSelectedVersion] = useState<number>(currentArtifactVersion);
+  const { selectedVersion, selectVersion } = useArtifactVersionSelection(
+    artifactId,
+    currentArtifactVersion
+  );
 
-  // CRITICAL: Sync selectedVersion when currentArtifactVersion changes (e.g., after artifact update)
-  // This ensures editability is not lost when artifact version increments
-  useEffect(() => {
-    if (currentArtifactVersion !== selectedVersion && selectedVersion < currentArtifactVersion) {
-      // Artifact was updated (version incremented) - sync to latest version
-      setSelectedVersion(currentArtifactVersion);
-    }
-  }, [currentArtifactVersion, selectedVersion]);
-
-  // Fetch version data if different from current (must be before early returns)
+  // Simple query: fetch version if different from current
   const versionData = useQuery(
     api.artifactVersionQueries.getVersionByNumber,
     selectedVersion !== currentArtifactVersion && artifactId
@@ -134,10 +129,8 @@ export function SchemaDrivenArtifactRenderer({
     )
   }
 
-  // versionData already fetched above (before early returns)
-
   // Use version data if available, otherwise use artifact
-  const displayArtifact = versionData && selectedVersion !== currentArtifactVersion
+  const displayArtifact = versionData
     ? {
         ...artifact,
         data: versionData.data,
@@ -172,7 +165,7 @@ export function SchemaDrivenArtifactRenderer({
           editButton={editButton}
           artifactId={artifactId as Id<'artifacts'> | undefined}
           selectedVersion={selectedVersion}
-          onVersionChange={setSelectedVersion}
+          onVersionChange={selectVersion}
         />
       )
     
@@ -188,7 +181,7 @@ export function SchemaDrivenArtifactRenderer({
           editButton={editButton}
           artifactId={artifactId as Id<'artifacts'> | undefined}
           selectedVersion={selectedVersion}
-          onVersionChange={setSelectedVersion}
+          onVersionChange={selectVersion}
         />
       )
     
@@ -204,7 +197,7 @@ export function SchemaDrivenArtifactRenderer({
           editButton={editButton}
           artifactId={artifactId as Id<'artifacts'> | undefined}
           selectedVersion={selectedVersion}
-          onVersionChange={setSelectedVersion}
+          onVersionChange={selectVersion}
         />
       )
     
@@ -220,7 +213,7 @@ export function SchemaDrivenArtifactRenderer({
           editButton={editButton}
           artifactId={artifactId as Id<'artifacts'> | undefined}
           selectedVersion={selectedVersion}
-          onVersionChange={setSelectedVersion}
+          onVersionChange={selectVersion}
         />
       )
     
@@ -236,7 +229,7 @@ export function SchemaDrivenArtifactRenderer({
           editButton={editButton}
           artifactId={artifactId as Id<'artifacts'> | undefined}
           selectedVersion={selectedVersion}
-          onVersionChange={setSelectedVersion}
+          onVersionChange={selectVersion}
         />
       )
     
@@ -252,7 +245,7 @@ export function SchemaDrivenArtifactRenderer({
           editButton={editButton}
           artifactId={artifactId as Id<'artifacts'> | undefined}
           selectedVersion={selectedVersion}
-          onVersionChange={setSelectedVersion}
+          onVersionChange={selectVersion}
         />
       )
     
@@ -268,7 +261,7 @@ export function SchemaDrivenArtifactRenderer({
           editButton={editButton}
           artifactId={artifactId as Id<'artifacts'> | undefined}
           selectedVersion={selectedVersion}
-          onVersionChange={setSelectedVersion}
+          onVersionChange={selectVersion}
         />
       )
     

--- a/src/hooks/useArtifactVersionSelection.ts
+++ b/src/hooks/useArtifactVersionSelection.ts
@@ -1,0 +1,50 @@
+/**
+ * ARTIFACT VERSION SELECTION HOOK
+ * 
+ * State management hook for artifact version selection.
+ * Handles version selection via URL state (source of truth).
+ * 
+ * PATTERN COMPLIANCE:
+ * - Pure logic, no UI
+ * - React hooks best practices
+ * - URL synchronization via router.replace (no history spam)
+ * - Follows useGalleryNavigation.ts pattern
+ * 
+ * LAW VI: This is the new Gold Standard for version selection.
+ * Can be reused for any versioned content (artifacts, notes, widgets).
+ */
+
+import { useCallback } from 'react'
+import { useRouter, useSearchParams, usePathname } from 'next/navigation'
+
+export function useArtifactVersionSelection(
+  artifactId: string | null,
+  currentVersion: number,
+  defaultVersion?: number
+) {
+  const router = useRouter()
+  const searchParams = useSearchParams()
+  const pathname = usePathname()
+  
+  // Read version from URL (source of truth)
+  const urlVersion = searchParams.get('version')
+  const selectedVersion = urlVersion 
+    ? parseInt(urlVersion, 10) 
+    : (defaultVersion ?? currentVersion)
+  
+  // Update URL when version changes (never sync with props)
+  const selectVersion = useCallback((version: number) => {
+    const params = new URLSearchParams(searchParams.toString())
+    if (version === currentVersion) {
+      params.delete('version') // Remove param if viewing current
+    } else {
+      params.set('version', version.toString())
+    }
+    const queryString = params.toString()
+    const newUrl = queryString ? `${pathname}?${queryString}` : pathname
+    router.replace(newUrl, { scroll: false })
+  }, [router, searchParams, pathname, currentVersion])
+  
+  return { selectedVersion, selectVersion }
+}
+


### PR DESCRIPTION
- Updated `getProjectArtifacts` query to include checks for project existence and user permissions, ensuring only authorized users can access project artifacts.
- Refactored `SchemaDrivenArtifactRenderer` to utilize a new `useArtifactVersionSelection` hook for managing artifact version state via URL, improving user experience and maintaining synchronization with the current version.
- Added `useArtifactVersionSelection` hook to handle version selection logic, including URL synchronization and state management, establishing a reusable pattern for versioned content.

These changes aim to improve access control and enhance the user experience when interacting with artifacts and their versions.